### PR TITLE
Add script helper to gocd-tasks

### DIFF
--- a/test/testdata/sample-bash.sh
+++ b/test/testdata/sample-bash.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "world";

--- a/test/testdata/v1.0.0-gocd-tasks-noop.jsonnet
+++ b/test/testdata/v1.0.0-gocd-tasks-noop.jsonnet
@@ -1,0 +1,7 @@
+local gocdtasks = import '../../v1.0.0/gocd-tasks.libsonnet';
+
+{
+  tasks: [
+    gocdtasks.noop,
+  ],
+}

--- a/test/testdata/v1.0.0-gocd-tasks-noop.jsonnet.golden
+++ b/test/testdata/v1.0.0-gocd-tasks-noop.jsonnet.golden
@@ -1,0 +1,9 @@
+{
+   "tasks": [
+      {
+         "exec": {
+            "command": true
+         }
+      }
+   ]
+}

--- a/test/testdata/v1.0.0-gocd-tasks-script.jsonnet
+++ b/test/testdata/v1.0.0-gocd-tasks-script.jsonnet
@@ -1,0 +1,8 @@
+local gocdtasks = import '../../v1.0.0/gocd-tasks.libsonnet';
+
+{
+  tasks: [
+    gocdtasks.script("echo 'hello'"),
+    gocdtasks.script(importstr './sample-bash.sh'),
+  ],
+}

--- a/test/testdata/v1.0.0-gocd-tasks-script.jsonnet.golden
+++ b/test/testdata/v1.0.0-gocd-tasks-script.jsonnet.golden
@@ -1,0 +1,10 @@
+{
+   "tasks": [
+      {
+         "script": "echo 'hello'"
+      },
+      {
+         "script": "#!/bin/bash\n\necho \"world\";\n"
+      }
+   ]
+}

--- a/test/v1.0.0/gocd-tasks.js
+++ b/test/v1.0.0/gocd-tasks.js
@@ -1,0 +1,12 @@
+import test from 'ava';
+import {assert_testdata} from '../utils/testdata.js';
+
+const files = [
+  'v1.0.0-gocd-tasks-noop.jsonnet',
+  'v1.0.0-gocd-tasks-script.jsonnet',
+];
+for (const f of files) {
+  test(`render ${f}`, async t => {
+    await assert_testdata(t, f);
+  });
+}

--- a/v1.0.0/gocd-tasks.libsonnet
+++ b/v1.0.0/gocd-tasks.libsonnet
@@ -4,4 +4,7 @@
       command: true,
     },
   },
+  script(input):: {
+    script: input,
+  },
 }


### PR DESCRIPTION
This is a fairly silly task, but it changes:

```
tasks: [
	{
		script: importstr './bash.sh',
	},
]
```

into:

```
tasks: [
	gocd_tasks.script(importstr './bash.sh'),
]
```

So the readability for pipelines are greatly improved IMO