### PR TITLE
Ensure unique upstream material name

### DIFF
--- a/test/testdata/v1.0.0/pipedream/autodeploy.jsonnet.golden
+++ b/test/testdata/v1.0.0/pipedream/autodeploy.jsonnet.golden
@@ -11,7 +11,7 @@
                   "git": "git@github.com:getsentry/example.git",
                   "shallow_clone": true
                },
-               "upstream_pipeline": {
+               "region-deploy-example-us-pipeline-complete": {
                   "pipeline": "region-deploy-example-us",
                   "stage": "pipeline-complete"
                }
@@ -50,15 +50,15 @@
          "region-deploy-example-us": {
             "group": "example-region-deployments",
             "materials": {
+               "deploy-example-pipeline-complete": {
+                  "pipeline": "deploy-example",
+                  "stage": "pipeline-complete"
+               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
                   "git": "git@github.com:getsentry/example.git",
                   "shallow_clone": true
-               },
-               "upstream_pipeline": {
-                  "pipeline": "deploy-example",
-                  "stage": "pipeline-complete"
                }
             },
             "region": "us",

--- a/test/testdata/v1.0.0/pipedream/minimal-config.jsonnet.golden
+++ b/test/testdata/v1.0.0/pipedream/minimal-config.jsonnet.golden
@@ -11,7 +11,7 @@
                   "git": "git@github.com:getsentry/example.git",
                   "shallow_clone": true
                },
-               "upstream_pipeline": {
+               "region-deploy-example-us-pipeline-complete": {
                   "pipeline": "region-deploy-example-us",
                   "stage": "pipeline-complete"
                }
@@ -50,15 +50,15 @@
          "region-deploy-example-us": {
             "group": "example-region-deployments",
             "materials": {
+               "deploy-example-pipeline-complete": {
+                  "pipeline": "deploy-example",
+                  "stage": "pipeline-complete"
+               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
                   "git": "git@github.com:getsentry/example.git",
                   "shallow_clone": true
-               },
-               "upstream_pipeline": {
-                  "pipeline": "deploy-example",
-                  "stage": "pipeline-complete"
                }
             },
             "region": "us",

--- a/test/testdata/v1.0.0/pipedream/no-autodeploy.jsonnet.golden
+++ b/test/testdata/v1.0.0/pipedream/no-autodeploy.jsonnet.golden
@@ -11,7 +11,7 @@
                   "git": "git@github.com:getsentry/example.git",
                   "shallow_clone": true
                },
-               "upstream_pipeline": {
+               "region-deploy-example-us-pipeline-complete": {
                   "pipeline": "region-deploy-example-us",
                   "stage": "pipeline-complete"
                }
@@ -83,15 +83,15 @@
          "region-deploy-example-us": {
             "group": "example-region-deployments",
             "materials": {
+               "deploy-example-pipeline-complete": {
+                  "pipeline": "deploy-example",
+                  "stage": "pipeline-complete"
+               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
                   "git": "git@github.com:getsentry/example.git",
                   "shallow_clone": true
-               },
-               "upstream_pipeline": {
-                  "pipeline": "deploy-example",
-                  "stage": "pipeline-complete"
                }
             },
             "region": "us",

--- a/v1.0.0/pipedream.libsonnet
+++ b/v1.0.0/pipedream.libsonnet
@@ -67,7 +67,7 @@ local generate_pipeline(pipedream_config, region, pipeline_fn) =
       [pipeline_name(service_name, region)]+: {
         group: service_name + '-region-deployments',
         materials+: {
-          upstream_pipeline: {
+          [upstream_pipeline + '-' + FINAL_STAGE_NAME]: {
             pipeline: upstream_pipeline,
             stage: FINAL_STAGE_NAME,
           },


### PR DESCRIPTION
From @joshuarli :

> If you have a different name for the same pipeline+stage it won't be allowed. I just try to avoid this potential problem altogether by naming them pipeline-stage.

This PR changes the name for the material to ensure it's always the same.