### PR TITLE
Update ordering of pipelines and use a single group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
+.DEFAULT_GOAL := all
+
+all: fmt lint test
+.PHONY: all
+
 fmt:
 	./scripts/fmt.sh
+.PHONY: fmt
 
 lint:
 	./scripts/lint.sh
+.PHONY: lint
+
+test:
+	npm run test
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -112,3 +112,11 @@ gocdstages.basic('example-stage', [gocdtasks.noop], {approval: 'manual'})
 # A single job stage, with a noop task and allow only on success approval
 gocdstages.basic('example-stage', [gocdtasks.noop], {approval: 'success'})
 ```
+
+## Development
+
+Run formatting, lint and tests using make:
+
+```shell
+make
+```

--- a/test/testdata/v1.0.0/pipedream/autodeploy.jsonnet.golden
+++ b/test/testdata/v1.0.0/pipedream/autodeploy.jsonnet.golden
@@ -3,7 +3,8 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-monitor": {
-            "group": "example-regions",
+            "display_order_weight": 1,
+            "group": "example",
             "materials": {
                "deploy-example-us-pipeline-complete": {
                   "pipeline": "deploy-example-us",
@@ -48,7 +49,8 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-us": {
-            "group": "example-regions",
+            "display_order_weight": 2,
+            "group": "example",
             "materials": {
                "deploy-example-pipeline-complete": {
                   "pipeline": "deploy-example",
@@ -93,6 +95,7 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example": {
+            "display_order_weight": 3,
             "group": "example",
             "lock_behavior": "unlockWhenFinished",
             "materials": {

--- a/test/testdata/v1.0.0/pipedream/minimal-config.jsonnet.golden
+++ b/test/testdata/v1.0.0/pipedream/minimal-config.jsonnet.golden
@@ -3,7 +3,8 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-monitor": {
-            "group": "example-regions",
+            "display_order_weight": 1,
+            "group": "example",
             "materials": {
                "deploy-example-us-pipeline-complete": {
                   "pipeline": "deploy-example-us",
@@ -48,7 +49,8 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-us": {
-            "group": "example-regions",
+            "display_order_weight": 2,
+            "group": "example",
             "materials": {
                "deploy-example-pipeline-complete": {
                   "pipeline": "deploy-example",
@@ -93,6 +95,7 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example": {
+            "display_order_weight": 3,
             "group": "example",
             "lock_behavior": "unlockWhenFinished",
             "materials": {

--- a/test/testdata/v1.0.0/pipedream/no-autodeploy.jsonnet.golden
+++ b/test/testdata/v1.0.0/pipedream/no-autodeploy.jsonnet.golden
@@ -3,7 +3,8 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-monitor": {
-            "group": "example-regions",
+            "display_order_weight": 1,
+            "group": "example",
             "materials": {
                "deploy-example-us-pipeline-complete": {
                   "pipeline": "deploy-example-us",
@@ -81,7 +82,8 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-us": {
-            "group": "example-regions",
+            "display_order_weight": 2,
+            "group": "example",
             "materials": {
                "deploy-example-pipeline-complete": {
                   "pipeline": "deploy-example",
@@ -159,6 +161,7 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example": {
+            "display_order_weight": 3,
             "group": "example",
             "lock_behavior": "unlockWhenFinished",
             "materials": {

--- a/v1.0.0/pipedream.libsonnet
+++ b/v1.0.0/pipedream.libsonnet
@@ -38,6 +38,7 @@ local pipedream_trigger_pipeline(pipedream_config) =
       pipelines: {
         [pipeline_name(name)]: {
           group: name,
+          display_order_weight: std.length(REGIONS) + 1,
           materials: materials,
           lock_behavior: 'unlockWhenFinished',
           stages: [
@@ -50,7 +51,7 @@ local pipedream_trigger_pipeline(pipedream_config) =
 
 // generate_pipeline will call the pipeline callback function, and then
 // name the pipeline, add an upstream material, and append a final stage.
-local generate_pipeline(pipedream_config, region, pipeline_fn) =
+local generate_pipeline(pipedream_config, region, weight, pipeline_fn) =
   // Get previous region's pipeline name
   local service_name = pipedream_config.name;
   local index = std.find(region, REGIONS)[0];
@@ -86,7 +87,8 @@ local generate_pipeline(pipedream_config, region, pipeline_fn) =
   service_pipeline {
     pipelines+: {
       [pipeline_name(service_name, region)]+: {
-        group: service_name + '-regions',
+        group: service_name,
+        display_order_weight: weight,
         materials+: {
           [upstream_pipeline + '-' + FINAL_STAGE_NAME]: {
             pipeline: upstream_pipeline,
@@ -104,8 +106,8 @@ local generate_pipeline(pipedream_config, region, pipeline_fn) =
 // for each region.
 local get_service_pipelines(pipedream_config, pipeline_fn) =
   {
-    [pipedream_config.name + '-' + region + '.yaml']: generate_pipeline(pipedream_config, region, pipeline_fn)
-    for region in REGIONS
+    [pipedream_config.name + '-' + REGIONS[i] + '.yaml']: generate_pipeline(pipedream_config, REGIONS[i], std.length(REGIONS) - i, pipeline_fn)
+    for i in std.range(0, std.length(REGIONS) - 1)
   };
 
 {


### PR DESCRIPTION
GoCD will order pipelines in order of highest weight to lowest.

This change will ensure ordering of pipedream pipelines in order of deployments.