### PR TITLE
Removing customer-4 from pipedream (for now)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -24,7 +24,6 @@ local REGIONS = [
   'customer-1',
   'customer-2',
   'customer-3',
-  'customer-4',
 ];
 // Test regions will deploy in parallel to the regions above
 local TEST_REGIONS = [

--- a/test/testdata/pipedream/autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/pipedream/autodeploy.jsonnet_output-files.golden
@@ -137,57 +137,11 @@
          }
       }
    },
-   "example-customer-4.yaml": {
-      "format_version": 10,
-      "pipelines": {
-         "deploy-example-customer-4": {
-            "display_order": 7,
-            "group": "example",
-            "materials": {
-               "deploy-example-customer-3-pipeline-complete": {
-                  "pipeline": "deploy-example-customer-3",
-                  "stage": "pipeline-complete"
-               },
-               "example_repo": {
-                  "branch": "master",
-                  "destination": "example",
-                  "git": "git@github.com:getsentry/example.git",
-                  "shallow_clone": true
-               }
-            },
-            "region": "customer-4",
-            "stages": [
-               {
-                  "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      }
-   },
    "example-customer-5.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-5": {
-            "display_order": 8,
+            "display_order": 7,
             "group": "example",
             "materials": {
                "example_repo": {
@@ -229,7 +183,7 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-6": {
-            "display_order": 9,
+            "display_order": 8,
             "group": "example",
             "materials": {
                "example_repo": {
@@ -361,17 +315,17 @@
          "rollback-example": {
             "display_order": 1,
             "environment_variables": {
-               "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
+               "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
                "GOCD_ACCESS_TOKEN": "{{SECRET:[devinfra][gocd_access_token]}}",
-               "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
+               "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
                "ROLLBACK_MATERIAL_NAME": "example_repo",
                "ROLLBACK_STAGE": "example_stage"
             },
             "group": "example",
             "lock_behavior": "unlockWhenFinished",
             "materials": {
-               "deploy-example-customer-4-pipeline-complete": {
-                  "pipeline": "deploy-example-customer-4",
+               "deploy-example-customer-3-pipeline-complete": {
+                  "pipeline": "deploy-example-customer-3",
                   "stage": "pipeline-complete"
                }
             },

--- a/test/testdata/pipedream/autodeploy.jsonnet_single-file.golden
+++ b/test/testdata/pipedream/autodeploy.jsonnet_single-file.golden
@@ -124,49 +124,8 @@
             }
          ]
       },
-      "deploy-example-customer-4": {
-         "display_order": 7,
-         "group": "example",
-         "materials": {
-            "deploy-example-customer-3-pipeline-complete": {
-               "pipeline": "deploy-example-customer-3",
-               "stage": "pipeline-complete"
-            },
-            "example_repo": {
-               "branch": "master",
-               "destination": "example",
-               "git": "git@github.com:getsentry/example.git",
-               "shallow_clone": true
-            }
-         },
-         "region": "customer-4",
-         "stages": [
-            {
-               "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            }
-         ]
-      },
       "deploy-example-customer-5": {
-         "display_order": 8,
+         "display_order": 7,
          "group": "example",
          "materials": {
             "example_repo": {
@@ -203,7 +162,7 @@
          ]
       },
       "deploy-example-customer-6": {
-         "display_order": 9,
+         "display_order": 8,
          "group": "example",
          "materials": {
             "example_repo": {
@@ -320,17 +279,17 @@
       "rollback-example": {
          "display_order": 1,
          "environment_variables": {
-            "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
+            "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
             "GOCD_ACCESS_TOKEN": "{{SECRET:[devinfra][gocd_access_token]}}",
-            "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
+            "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
             "ROLLBACK_MATERIAL_NAME": "example_repo",
             "ROLLBACK_STAGE": "example_stage"
          },
          "group": "example",
          "lock_behavior": "unlockWhenFinished",
          "materials": {
-            "deploy-example-customer-4-pipeline-complete": {
-               "pipeline": "deploy-example-customer-4",
+            "deploy-example-customer-3-pipeline-complete": {
+               "pipeline": "deploy-example-customer-3",
                "stage": "pipeline-complete"
             }
          },

--- a/test/testdata/pipedream/minimal-config.jsonnet_output-files.golden
+++ b/test/testdata/pipedream/minimal-config.jsonnet_output-files.golden
@@ -137,57 +137,11 @@
          }
       }
    },
-   "example-customer-4.yaml": {
-      "format_version": 10,
-      "pipelines": {
-         "deploy-example-customer-4": {
-            "display_order": 7,
-            "group": "example",
-            "materials": {
-               "deploy-example-customer-3-pipeline-complete": {
-                  "pipeline": "deploy-example-customer-3",
-                  "stage": "pipeline-complete"
-               },
-               "example_repo": {
-                  "branch": "master",
-                  "destination": "example",
-                  "git": "git@github.com:getsentry/example.git",
-                  "shallow_clone": true
-               }
-            },
-            "region": "customer-4",
-            "stages": [
-               {
-                  "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      }
-   },
    "example-customer-5.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-5": {
-            "display_order": 8,
+            "display_order": 7,
             "group": "example",
             "materials": {
                "example_repo": {
@@ -229,7 +183,7 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-6": {
-            "display_order": 9,
+            "display_order": 8,
             "group": "example",
             "materials": {
                "example_repo": {

--- a/test/testdata/pipedream/minimal-config.jsonnet_single-file.golden
+++ b/test/testdata/pipedream/minimal-config.jsonnet_single-file.golden
@@ -124,49 +124,8 @@
             }
          ]
       },
-      "deploy-example-customer-4": {
-         "display_order": 7,
-         "group": "example",
-         "materials": {
-            "deploy-example-customer-3-pipeline-complete": {
-               "pipeline": "deploy-example-customer-3",
-               "stage": "pipeline-complete"
-            },
-            "example_repo": {
-               "branch": "master",
-               "destination": "example",
-               "git": "git@github.com:getsentry/example.git",
-               "shallow_clone": true
-            }
-         },
-         "region": "customer-4",
-         "stages": [
-            {
-               "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            }
-         ]
-      },
       "deploy-example-customer-5": {
-         "display_order": 8,
+         "display_order": 7,
          "group": "example",
          "materials": {
             "example_repo": {
@@ -203,7 +162,7 @@
          ]
       },
       "deploy-example-customer-6": {
-         "display_order": 9,
+         "display_order": 8,
          "group": "example",
          "materials": {
             "example_repo": {

--- a/test/testdata/pipedream/no-autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/pipedream/no-autodeploy.jsonnet_output-files.golden
@@ -236,90 +236,11 @@
          }
       }
    },
-   "example-customer-4.yaml": {
-      "format_version": 10,
-      "pipelines": {
-         "deploy-example-customer-4": {
-            "display_order": 7,
-            "group": "example",
-            "materials": {
-               "deploy-example-customer-3-pipeline-complete": {
-                  "pipeline": "deploy-example-customer-3",
-                  "stage": "pipeline-complete"
-               },
-               "example_repo": {
-                  "branch": "master",
-                  "destination": "example",
-                  "git": "git@github.com:getsentry/example.git",
-                  "shallow_clone": true
-               }
-            },
-            "region": "customer-4",
-            "stages": [
-               {
-                  "ready": {
-                     "jobs": {
-                        "ready": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               },
-               {
-                  "wait": {
-                     "approval": {
-                        "type": "manual"
-                     },
-                     "jobs": {
-                        "wait": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               },
-               {
-                  "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      }
-   },
    "example-customer-5.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-5": {
-            "display_order": 8,
+            "display_order": 7,
             "group": "example",
             "materials": {
                "deploy-example-pipeline-complete": {
@@ -398,7 +319,7 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-6": {
-            "display_order": 9,
+            "display_order": 8,
             "group": "example",
             "materials": {
                "deploy-example-pipeline-complete": {
@@ -675,17 +596,17 @@
          "rollback-example": {
             "display_order": 1,
             "environment_variables": {
-               "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6 --pipeline=deploy-example",
+               "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6 --pipeline=deploy-example",
                "GOCD_ACCESS_TOKEN": "{{SECRET:[devinfra][gocd_access_token]}}",
-               "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
+               "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
                "ROLLBACK_MATERIAL_NAME": "example_repo",
                "ROLLBACK_STAGE": "example_stage"
             },
             "group": "example",
             "lock_behavior": "unlockWhenFinished",
             "materials": {
-               "deploy-example-customer-4-pipeline-complete": {
-                  "pipeline": "deploy-example-customer-4",
+               "deploy-example-customer-3-pipeline-complete": {
+                  "pipeline": "deploy-example-customer-3",
                   "stage": "pipeline-complete"
                }
             },

--- a/test/testdata/pipedream/no-autodeploy.jsonnet_single-file.golden
+++ b/test/testdata/pipedream/no-autodeploy.jsonnet_single-file.golden
@@ -256,82 +256,8 @@
             }
          ]
       },
-      "deploy-example-customer-4": {
-         "display_order": 7,
-         "group": "example",
-         "materials": {
-            "deploy-example-customer-3-pipeline-complete": {
-               "pipeline": "deploy-example-customer-3",
-               "stage": "pipeline-complete"
-            },
-            "example_repo": {
-               "branch": "master",
-               "destination": "example",
-               "git": "git@github.com:getsentry/example.git",
-               "shallow_clone": true
-            }
-         },
-         "region": "customer-4",
-         "stages": [
-            {
-               "ready": {
-                  "jobs": {
-                     "ready": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            },
-            {
-               "wait": {
-                  "approval": {
-                     "type": "manual"
-                  },
-                  "jobs": {
-                     "wait": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            },
-            {
-               "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            }
-         ]
-      },
       "deploy-example-customer-5": {
-         "display_order": 8,
+         "display_order": 7,
          "group": "example",
          "materials": {
             "deploy-example-pipeline-complete": {
@@ -405,7 +331,7 @@
          ]
       },
       "deploy-example-customer-6": {
-         "display_order": 9,
+         "display_order": 8,
          "group": "example",
          "materials": {
             "deploy-example-pipeline-complete": {
@@ -629,17 +555,17 @@
       "rollback-example": {
          "display_order": 1,
          "environment_variables": {
-            "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6 --pipeline=deploy-example",
+            "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6 --pipeline=deploy-example",
             "GOCD_ACCESS_TOKEN": "{{SECRET:[devinfra][gocd_access_token]}}",
-            "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
+            "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-s4s --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-5 --pipeline=deploy-example-customer-6",
             "ROLLBACK_MATERIAL_NAME": "example_repo",
             "ROLLBACK_STAGE": "example_stage"
          },
          "group": "example",
          "lock_behavior": "unlockWhenFinished",
          "materials": {
-            "deploy-example-customer-4-pipeline-complete": {
-               "pipeline": "deploy-example-customer-4",
+            "deploy-example-customer-3-pipeline-complete": {
+               "pipeline": "deploy-example-customer-3",
                "stage": "pipeline-complete"
             }
          },


### PR DESCRIPTION
Due to the current nature of the rollback pipeline, and having deploys paused for customer-4 for the foreseeable future, it makes sense to "un-chain" it by removing it, thereby helping mitigating problems with the rollback pipeline in the future.