### PR TITLE
Add support to exclude a region from pipedream

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ local pipedream_config = {
   auto_deploy: false,
   # Set to true if you want each pipeline to require manual approval
   auto_pipeline_progression: false,
+
+  # If there is ever a situation where you need to remove a region from
+  # a pipedream, add the region name to this array.
+  exclude_regions: [],
 };
 
 # You'll need to define a jsonnet function that describes your pipeline

--- a/test/getsentry.js
+++ b/test/getsentry.js
@@ -1,9 +1,7 @@
 import test from 'ava';
-import {assert_testdata} from './utils/testdata.js';
+import {assert_testdata, get_fixtures} from './utils/testdata.js';
 
-const files = [
-  'getsentry/is-st.jsonnet',
-];
+const files = await get_fixtures('getsentry');
 for (const f of files) {
   test(`render ${f}`, async t => {
     await assert_testdata(t, f);

--- a/test/gocd-stages.js
+++ b/test/gocd-stages.js
@@ -1,11 +1,7 @@
 import test from 'ava';
-import {assert_testdata} from './utils/testdata.js';
+import {assert_testdata, get_fixtures} from './utils/testdata.js';
 
-const files = [
-  'gocd-stages/basic-no-opts.jsonnet',
-  'gocd-stages/basic-manual-approval.jsonnet',
-  'gocd-stages/basic-success-approval.jsonnet',
-];
+const files = await get_fixtures('gocd-stages');
 for (const f of files) {
   test(`render ${f}`, async t => {
     await assert_testdata(t, f);

--- a/test/gocd-tasks.js
+++ b/test/gocd-tasks.js
@@ -1,10 +1,7 @@
 import test from 'ava';
-import {assert_testdata} from './utils/testdata.js';
+import {assert_testdata, get_fixtures} from './utils/testdata.js';
 
-const files = [
-  'gocd-tasks/noop.jsonnet',
-  'gocd-tasks/script.jsonnet',
-];
+const files = await get_fixtures('gocd-tasks');
 for (const f of files) {
   test(`render ${f}`, async t => {
     await assert_testdata(t, f);

--- a/test/pipedream.js
+++ b/test/pipedream.js
@@ -1,17 +1,13 @@
 import test from 'ava';
-import {assert_testdata} from './utils/testdata.js';
+import {assert_testdata, get_fixtures} from './utils/testdata.js';
 
-const files = [
-  'pipedream/no-autodeploy.jsonnet',
-  'pipedream/autodeploy.jsonnet',
-  'pipedream/minimal-config.jsonnet',
-];
+const files = await get_fixtures('pipedream');
 for (const f of files) {
-  test(`render ${f} as files`, async t => {
+  test(`render ${f} as multiple files`, async t => {
     await assert_testdata(t, f, true);
   });
 
-  test(`render ${f} as single file`, async t => {
+  test(`render ${f} as a single file`, async t => {
     await assert_testdata(t, f, false);
   });
 }

--- a/test/testdata/fixtures/pipedream/exclude-regions.jsonnet
+++ b/test/testdata/fixtures/pipedream/exclude-regions.jsonnet
@@ -1,0 +1,34 @@
+local pipedream = import '../../../../libs/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'example',
+  exclude_regions: ['us', 'customer-3', 'customer-5'],
+  materials: {
+    init_repo: {
+      git: 'git@github.com:getsentry/init.git',
+      branch: 'master',
+      destination: 'init',
+    },
+  },
+};
+
+local sample = {
+  pipeline(region):: {
+    region: region,
+    materials: {
+      example_repo: {
+        git: 'git@github.com:getsentry/example.git',
+        shallow_clone: true,
+        branch: 'master',
+        destination: 'example',
+      },
+    },
+    stages: [
+      {
+        example_stage: {},
+      },
+    ],
+  },
+};
+
+pipedream.render(pipedream_config, sample.pipeline)

--- a/test/testdata/goldens/pipedream/autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/autodeploy.jsonnet_output-files.golden
@@ -1,5 +1,5 @@
 {
-   "example-customer-1.yaml": {
+   "deploy-example-customer-1.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-1": {
@@ -45,7 +45,7 @@
          }
       }
    },
-   "example-customer-2.yaml": {
+   "deploy-example-customer-2.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-2": {
@@ -91,7 +91,7 @@
          }
       }
    },
-   "example-customer-3.yaml": {
+   "deploy-example-customer-3.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-3": {
@@ -137,7 +137,7 @@
          }
       }
    },
-   "example-customer-4.yaml": {
+   "deploy-example-customer-4.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-4": {
@@ -183,7 +183,7 @@
          }
       }
    },
-   "example-customer-5.yaml": {
+   "deploy-example-customer-5.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-5": {
@@ -225,7 +225,7 @@
          }
       }
    },
-   "example-customer-6.yaml": {
+   "deploy-example-customer-6.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-6": {
@@ -267,7 +267,7 @@
          }
       }
    },
-   "example-s4s.yaml": {
+   "deploy-example-s4s.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-s4s": {
@@ -309,7 +309,7 @@
          }
       }
    },
-   "example-us.yaml": {
+   "deploy-example-us.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-us": {

--- a/test/testdata/goldens/pipedream/exclude-regions.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/exclude-regions.jsonnet_output-files.golden
@@ -3,11 +3,11 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-1": {
-            "display_order": 4,
+            "display_order": 3,
             "group": "example",
             "materials": {
-               "deploy-example-us-pipeline-complete": {
-                  "pipeline": "deploy-example-us",
+               "deploy-example-s4s-pipeline-complete": {
+                  "pipeline": "deploy-example-s4s",
                   "stage": "pipeline-complete"
                },
                "example_repo": {
@@ -49,7 +49,7 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-2": {
-            "display_order": 5,
+            "display_order": 4,
             "group": "example",
             "materials": {
                "deploy-example-customer-1-pipeline-complete": {
@@ -91,61 +91,15 @@
          }
       }
    },
-   "deploy-example-customer-3.yaml": {
-      "format_version": 10,
-      "pipelines": {
-         "deploy-example-customer-3": {
-            "display_order": 6,
-            "group": "example",
-            "materials": {
-               "deploy-example-customer-2-pipeline-complete": {
-                  "pipeline": "deploy-example-customer-2",
-                  "stage": "pipeline-complete"
-               },
-               "example_repo": {
-                  "branch": "master",
-                  "destination": "example",
-                  "git": "git@github.com:getsentry/example.git",
-                  "shallow_clone": true
-               }
-            },
-            "region": "customer-3",
-            "stages": [
-               {
-                  "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      }
-   },
    "deploy-example-customer-4.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-4": {
-            "display_order": 7,
+            "display_order": 5,
             "group": "example",
             "materials": {
-               "deploy-example-customer-3-pipeline-complete": {
-                  "pipeline": "deploy-example-customer-3",
+               "deploy-example-customer-2-pipeline-complete": {
+                  "pipeline": "deploy-example-customer-2",
                   "stage": "pipeline-complete"
                },
                "example_repo": {
@@ -183,53 +137,11 @@
          }
       }
    },
-   "deploy-example-customer-5.yaml": {
-      "format_version": 10,
-      "pipelines": {
-         "deploy-example-customer-5": {
-            "display_order": 8,
-            "group": "example",
-            "materials": {
-               "example_repo": {
-                  "branch": "master",
-                  "destination": "example",
-                  "git": "git@github.com:getsentry/example.git",
-                  "shallow_clone": true
-               }
-            },
-            "region": "customer-5",
-            "stages": [
-               {
-                  "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      }
-   },
    "deploy-example-customer-6.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-6": {
-            "display_order": 9,
+            "display_order": 6,
             "group": "example",
             "materials": {
                "example_repo": {
@@ -282,52 +194,6 @@
                }
             },
             "region": "s4s",
-            "stages": [
-               {
-                  "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      }
-   },
-   "deploy-example-us.yaml": {
-      "format_version": 10,
-      "pipelines": {
-         "deploy-example-us": {
-            "display_order": 3,
-            "group": "example",
-            "materials": {
-               "deploy-example-s4s-pipeline-complete": {
-                  "pipeline": "deploy-example-s4s",
-                  "stage": "pipeline-complete"
-               },
-               "example_repo": {
-                  "branch": "master",
-                  "destination": "example",
-                  "git": "git@github.com:getsentry/example.git",
-                  "shallow_clone": true
-               }
-            },
-            "region": "us",
             "stages": [
                {
                   "example_stage": { }

--- a/test/testdata/goldens/pipedream/exclude-regions.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/exclude-regions.jsonnet_single-file.golden
@@ -1,0 +1,202 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "deploy-example-customer-1": {
+         "display_order": 3,
+         "group": "example",
+         "materials": {
+            "deploy-example-s4s-pipeline-complete": {
+               "pipeline": "deploy-example-s4s",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "customer-1",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-customer-2": {
+         "display_order": 4,
+         "group": "example",
+         "materials": {
+            "deploy-example-customer-1-pipeline-complete": {
+               "pipeline": "deploy-example-customer-1",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "customer-2",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-customer-4": {
+         "display_order": 5,
+         "group": "example",
+         "materials": {
+            "deploy-example-customer-2-pipeline-complete": {
+               "pipeline": "deploy-example-customer-2",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "customer-4",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-customer-6": {
+         "display_order": 6,
+         "group": "example",
+         "materials": {
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "customer-6",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-s4s": {
+         "display_order": 2,
+         "group": "example",
+         "materials": {
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "s4s",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
@@ -1,5 +1,5 @@
 {
-   "example-customer-1.yaml": {
+   "deploy-example-customer-1.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-1": {
@@ -78,7 +78,7 @@
          }
       }
    },
-   "example-customer-2.yaml": {
+   "deploy-example-customer-2.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-2": {
@@ -157,7 +157,7 @@
          }
       }
    },
-   "example-customer-3.yaml": {
+   "deploy-example-customer-3.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-3": {
@@ -236,7 +236,7 @@
          }
       }
    },
-   "example-customer-4.yaml": {
+   "deploy-example-customer-4.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-4": {
@@ -315,7 +315,7 @@
          }
       }
    },
-   "example-customer-5.yaml": {
+   "deploy-example-customer-5.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-5": {
@@ -394,7 +394,7 @@
          }
       }
    },
-   "example-customer-6.yaml": {
+   "deploy-example-customer-6.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-customer-6": {
@@ -473,7 +473,7 @@
          }
       }
    },
-   "example-s4s.yaml": {
+   "deploy-example-s4s.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-s4s": {
@@ -552,7 +552,7 @@
          }
       }
    },
-   "example-us.yaml": {
+   "deploy-example-us.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-us": {

--- a/test/utils/testdata.js
+++ b/test/utils/testdata.js
@@ -29,3 +29,8 @@ export async function assert_testdata(t, filename, outputfiles=true) {
   // We still want the golden to match exactly
   t.is(got, want);
 }
+
+export async function get_fixtures(fixture_subdir) {
+  const files = await fs.readdir(path.join('test/testdata/fixtures', fixture_subdir));
+  return files.map((f) => path.join(fixture_subdir, f));
+}


### PR DESCRIPTION
There a couple of cleanup changes in this PR too:

- Use get_fixtures to get the set of jsonnet files to test against
- Use the pipeline name for the filename instead of generating a shorter name (this won't be noticed by folks as we will be removing generated pipelines from repos along with this change thanks to the GoCD Jsonnet plugin now working)