### PR TITLE
Remove pipeline-complete stage from pipelines

### DIFF
--- a/libs/gocd-pipelines.libsonnet
+++ b/libs/gocd-pipelines.libsonnet
@@ -1,0 +1,49 @@
+local chain_materials(current_pipeline, previous_pipeline) =
+  local final_stage = previous_pipeline.pipeline.stages[std.length(previous_pipeline.pipeline.stages) - 1];
+  local final_stage_name = std.objectFields(final_stage)[0];
+  current_pipeline {
+    pipeline+: {
+      materials+: {
+        [previous_pipeline.name + '-' + final_stage_name]: {
+          pipeline: previous_pipeline.name,
+          stage: final_stage_name,
+        },
+      },
+    },
+  };
+
+local chain_pipelines(pipelines) =
+  [pipelines[0]] + [
+    chain_materials(pipelines[i], pipelines[i - 1])
+    for i in std.range(1, std.length(pipelines) - 1)
+  ];
+
+// This method takes an array of pipelines and produces an object that contains
+// the pipelines in format:
+// { <pipeline name>.yaml: { ...GoCD metadata + <pipeline name>: <pipeline definition> }.
+// This is used to output each pipeline to a seperate file.
+local pipelines_to_files_object(pipelines) =
+  {
+    [pipelines[i].name + '.yaml']: {
+      format_version: 10,
+      pipelines: {
+        [pipelines[i].name]: pipelines[i].pipeline,
+      },
+    }
+    for i in std.range(0, std.length(pipelines) - 1)
+  };
+
+// This method takes an array of pipelines and produces an object that contains
+// the pipelines in format { <pipeline name>: <pipeline definition> }.
+// This is used to output all pipelines in a single file.
+local pipelines_to_object(pipelines) =
+  {
+    [pipelines[i].name]: pipelines[i].pipeline
+    for i in std.range(0, std.length(pipelines) - 1)
+  };
+
+{
+  chain_pipelines(pipelines):: chain_pipelines(pipelines),
+  pipelines_to_files_object(pipelines):: pipelines_to_files_object(pipelines),
+  pipelines_to_object(pipelines):: pipelines_to_object(pipelines),
+}

--- a/libs/gocd-pipelines.libsonnet
+++ b/libs/gocd-pipelines.libsonnet
@@ -1,12 +1,15 @@
+local final_stage_name(pipeline) =
+  local final_stage = pipeline.pipeline.stages[std.length(pipeline.pipeline.stages) - 1];
+  std.objectFields(final_stage)[0];
+
 local chain_materials(current_pipeline, previous_pipeline) =
-  local final_stage = previous_pipeline.pipeline.stages[std.length(previous_pipeline.pipeline.stages) - 1];
-  local final_stage_name = std.objectFields(final_stage)[0];
+  local final_stage = final_stage_name(previous_pipeline);
   current_pipeline {
     pipeline+: {
       materials+: {
-        [previous_pipeline.name + '-' + final_stage_name]: {
+        [previous_pipeline.name + '-' + final_stage]: {
           pipeline: previous_pipeline.name,
-          stage: final_stage_name,
+          stage: final_stage,
         },
       },
     },
@@ -46,4 +49,5 @@ local pipelines_to_object(pipelines) =
   chain_pipelines(pipelines):: chain_pipelines(pipelines),
   pipelines_to_files_object(pipelines):: pipelines_to_files_object(pipelines),
   pipelines_to_object(pipelines):: pipelines_to_object(pipelines),
+  final_stage_name(pipeline):: final_stage_name(pipeline),
 }

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -73,8 +73,7 @@ local pipedream_rollback_pipeline(pipedream_config, final_pipeline) =
     else
       region_pipeline_flags + ' --pipeline=' + pipeline_name(name);
 
-    local final_stage = final_pipeline.pipeline.stages[std.length(final_pipeline.pipeline.stages) - 1];
-    local final_stage_name = std.objectFields(final_stage)[0];
+    local final_stage = gocd_pipelines.final_stage_name(final_pipeline);
 
     {
       ['rollback-' + name]: {
@@ -88,9 +87,9 @@ local pipedream_rollback_pipeline(pipedream_config, final_pipeline) =
           ALL_PIPELINE_FLAGS: all_pipeline_flags,
         },
         materials: {
-          [final_pipeline.name + '-' + final_stage_name]: {
+          [final_pipeline.name + '-' + final_stage]: {
             pipeline: final_pipeline.name,
-            stage: final_stage_name,
+            stage: final_stage,
           },
         },
         lock_behavior: 'unlockWhenFinished',

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -15,6 +15,7 @@ and a final stage. The upstream material and final stage is to make GoCD
 chain the pipelines together.
 
 */
+local gocd_pipelines = import './gocd-pipelines.libsonnet';
 local gocd_stages = import './gocd-stages.libsonnet';
 local gocd_tasks = import './gocd-tasks.libsonnet';
 
@@ -31,7 +32,6 @@ local TEST_REGIONS = [
   'customer-5',
   'customer-6',
 ];
-local FINAL_STAGE_NAME = 'pipeline-complete';
 
 local pipeline_name(name, region=null) =
   if region != null then 'deploy-' + name + '-' + region else 'deploy-' + name;
@@ -58,12 +58,12 @@ local pipedream_trigger_pipeline(pipedream_config) =
         materials: materials,
         lock_behavior: 'unlockWhenFinished',
         stages: [
-          gocd_stages.basic(FINAL_STAGE_NAME, [gocd_tasks.noop], { approval: approval_type }),
+          gocd_stages.basic('pipeline-complete', [gocd_tasks.noop], { approval: approval_type }),
         ],
       },
     };
 
-local pipedream_rollback_pipeline(pipedream_config) =
+local pipedream_rollback_pipeline(pipedream_config, final_pipeline) =
   if std.objectHas(pipedream_config, 'rollback') then
     local name = pipedream_config.name;
     local region_pipeline_names = std.map(function(r) pipeline_name(name, r), REGIONS);
@@ -72,7 +72,9 @@ local pipedream_rollback_pipeline(pipedream_config) =
       region_pipeline_flags
     else
       region_pipeline_flags + ' --pipeline=' + pipeline_name(name);
-    local final_pipeline = pipeline_name(name, REGIONS[std.length(REGIONS) - 1]);
+
+    local final_stage = final_pipeline.pipeline.stages[std.length(final_pipeline.pipeline.stages) - 1];
+    local final_stage_name = std.objectFields(final_stage)[0];
 
     {
       ['rollback-' + name]: {
@@ -86,9 +88,9 @@ local pipedream_rollback_pipeline(pipedream_config) =
           ALL_PIPELINE_FLAGS: all_pipeline_flags,
         },
         materials: {
-          [final_pipeline + '-' + FINAL_STAGE_NAME]: {
-            pipeline: final_pipeline,
-            stage: FINAL_STAGE_NAME,
+          [final_pipeline.name + '-' + final_stage_name]: {
+            pipeline: final_pipeline.name,
+            stage: final_stage_name,
           },
         },
         lock_behavior: 'unlockWhenFinished',
@@ -131,14 +133,6 @@ local pipedream_rollback_pipeline(pipedream_config) =
 local generate_region_pipeline(pipedream_config, regions_to_chain, region, weight, pipeline_fn) =
   // Get previous region's pipeline name
   local service_name = pipedream_config.name;
-  local indexes = std.find(region, regions_to_chain);
-  local upstream_pipeline = if std.length(indexes) == 0 || indexes[0] == 0 then
-    if is_autodeploy(pipedream_config) then
-      null
-    else
-      pipeline_name(service_name)
-  else
-    pipeline_name(service_name, regions_to_chain[indexes[0] - 1]);
 
   local service_pipeline = pipeline_fn(
     region,
@@ -162,24 +156,20 @@ local generate_region_pipeline(pipedream_config, regions_to_chain, region, weigh
   service_pipeline {
     group: service_name,
     display_order: weight,
-    materials+: {
-      [if upstream_pipeline == null then null else upstream_pipeline + '-' + FINAL_STAGE_NAME]: {
-        pipeline: upstream_pipeline,
-        stage: FINAL_STAGE_NAME,
-      },
-    },
-    stages: prepend_stages + stages + [
-      gocd_stages.basic(FINAL_STAGE_NAME, [gocd_tasks.noop], { approval: 'success' }),
-    ],
+    stages: prepend_stages + stages,
   };
 
 // get_service_pipelines iterates over each region and generates the pipeline
 // for each region.
 local get_service_pipelines(pipedream_config, pipeline_fn, regions, regions_to_chain, display_offset) =
-  {
-    [pipeline_name(pipedream_config.name, regions[i])]: generate_region_pipeline(pipedream_config, regions_to_chain, regions[i], display_offset + i, pipeline_fn)
+  [
+    {
+      name: pipeline_name(pipedream_config.name, regions[i]),
+      pipeline: generate_region_pipeline(pipedream_config, regions_to_chain, regions[i], display_offset + i, pipeline_fn),
+    }
     for i in std.range(0, std.length(regions) - 1)
-  };
+  ];
+
 
 {
   // render will generate the trigger pipeline and all the region pipelines.
@@ -193,14 +183,12 @@ local get_service_pipelines(pipedream_config, pipeline_fn, regions, regions_to_c
       TEST_REGIONS,
     );
     local trigger_pipeline = pipedream_trigger_pipeline(pipedream_config);
-    local service_pipelines = get_service_pipelines(pipedream_config, pipeline_fn, regions_to_render, regions_to_render, 2);
+    local unchained_pipelines = get_service_pipelines(pipedream_config, pipeline_fn, regions_to_render, regions_to_render, 2);
+    local service_pipelines = gocd_pipelines.chain_pipelines(unchained_pipelines);
     local test_pipelines = get_service_pipelines(pipedream_config, pipeline_fn, test_regions_to_render, [], std.length(regions_to_render) + 2);
-    local rollback_pipeline = pipedream_rollback_pipeline(pipedream_config);
+    local rollback_pipeline = pipedream_rollback_pipeline(pipedream_config, service_pipelines[std.length(service_pipelines) - 1]);
 
     if std.extVar('output-files') then
-      local service_pipeline_names = std.objectFields(service_pipelines);
-      local test_pipeline_names = std.objectFields(test_pipelines);
-
       {
         [if trigger_pipeline == {} then null else pipedream_config.name + '.yaml']: {
           format_version: 10,
@@ -211,26 +199,14 @@ local get_service_pipelines(pipedream_config, pipeline_fn, regions, regions_to_c
           format_version: 10,
           pipelines: rollback_pipeline,
         },
-      } + {
-        [service_pipeline_names[i] + '.yaml']: {
-          format_version: 10,
-          pipelines: {
-            [service_pipeline_names[i]]: service_pipelines[service_pipeline_names[i]],
-          },
-        }
-        for i in std.range(0, std.length(service_pipeline_names) - 1)
-      } + {
-        [test_pipeline_names[i] + '.yaml']: {
-          format_version: 10,
-          pipelines: {
-            [test_pipeline_names[i]]: test_pipelines[test_pipeline_names[i]],
-          },
-        }
-        for i in std.range(0, std.length(test_pipeline_names) - 1)
-      }
+      } +
+      gocd_pipelines.pipelines_to_files_object(service_pipelines) +
+      gocd_pipelines.pipelines_to_files_object(test_pipelines)
     else
       {
         format_version: 10,
-        pipelines: trigger_pipeline + service_pipelines + test_pipelines + rollback_pipeline,
+        pipelines: trigger_pipeline + rollback_pipeline +
+                   gocd_pipelines.pipelines_to_object(service_pipelines) +
+                   gocd_pipelines.pipelines_to_object(test_pipelines),
       },
 }

--- a/test/testdata/goldens/pipedream/autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/autodeploy.jsonnet_output-files.golden
@@ -6,9 +6,9 @@
             "display_order": 4,
             "group": "example",
             "materials": {
-               "deploy-example-us-pipeline-complete": {
+               "deploy-example-us-example_stage": {
                   "pipeline": "deploy-example-us",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -21,25 +21,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -52,9 +33,9 @@
             "display_order": 5,
             "group": "example",
             "materials": {
-               "deploy-example-customer-1-pipeline-complete": {
+               "deploy-example-customer-1-example_stage": {
                   "pipeline": "deploy-example-customer-1",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -67,25 +48,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -98,9 +60,9 @@
             "display_order": 6,
             "group": "example",
             "materials": {
-               "deploy-example-customer-2-pipeline-complete": {
+               "deploy-example-customer-2-example_stage": {
                   "pipeline": "deploy-example-customer-2",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -113,25 +75,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -144,9 +87,9 @@
             "display_order": 7,
             "group": "example",
             "materials": {
-               "deploy-example-customer-3-pipeline-complete": {
+               "deploy-example-customer-3-example_stage": {
                   "pipeline": "deploy-example-customer-3",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -159,25 +102,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -201,25 +125,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -243,25 +148,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -285,25 +171,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -316,9 +183,9 @@
             "display_order": 3,
             "group": "example",
             "materials": {
-               "deploy-example-s4s-pipeline-complete": {
+               "deploy-example-s4s-example_stage": {
                   "pipeline": "deploy-example-s4s",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -331,25 +198,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -370,9 +218,9 @@
             "group": "example",
             "lock_behavior": "unlockWhenFinished",
             "materials": {
-               "deploy-example-customer-4-pipeline-complete": {
+               "deploy-example-customer-4-example_stage": {
                   "pipeline": "deploy-example-customer-4",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                }
             },
             "stages": [

--- a/test/testdata/goldens/pipedream/autodeploy.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/autodeploy.jsonnet_single-file.golden
@@ -5,9 +5,9 @@
          "display_order": 4,
          "group": "example",
          "materials": {
-            "deploy-example-us-pipeline-complete": {
+            "deploy-example-us-example_stage": {
                "pipeline": "deploy-example-us",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -20,25 +20,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -46,9 +27,9 @@
          "display_order": 5,
          "group": "example",
          "materials": {
-            "deploy-example-customer-1-pipeline-complete": {
+            "deploy-example-customer-1-example_stage": {
                "pipeline": "deploy-example-customer-1",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -61,25 +42,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -87,9 +49,9 @@
          "display_order": 6,
          "group": "example",
          "materials": {
-            "deploy-example-customer-2-pipeline-complete": {
+            "deploy-example-customer-2-example_stage": {
                "pipeline": "deploy-example-customer-2",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -102,25 +64,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -128,9 +71,9 @@
          "display_order": 7,
          "group": "example",
          "materials": {
-            "deploy-example-customer-3-pipeline-complete": {
+            "deploy-example-customer-3-example_stage": {
                "pipeline": "deploy-example-customer-3",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -143,25 +86,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -180,25 +104,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -217,25 +122,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -254,25 +140,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -280,9 +147,9 @@
          "display_order": 3,
          "group": "example",
          "materials": {
-            "deploy-example-s4s-pipeline-complete": {
+            "deploy-example-s4s-example_stage": {
                "pipeline": "deploy-example-s4s",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -295,25 +162,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -329,9 +177,9 @@
          "group": "example",
          "lock_behavior": "unlockWhenFinished",
          "materials": {
-            "deploy-example-customer-4-pipeline-complete": {
+            "deploy-example-customer-4-example_stage": {
                "pipeline": "deploy-example-customer-4",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             }
          },
          "stages": [

--- a/test/testdata/goldens/pipedream/exclude-regions.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/exclude-regions.jsonnet_output-files.golden
@@ -6,9 +6,9 @@
             "display_order": 3,
             "group": "example",
             "materials": {
-               "deploy-example-s4s-pipeline-complete": {
+               "deploy-example-s4s-example_stage": {
                   "pipeline": "deploy-example-s4s",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -21,25 +21,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -52,9 +33,9 @@
             "display_order": 4,
             "group": "example",
             "materials": {
-               "deploy-example-customer-1-pipeline-complete": {
+               "deploy-example-customer-1-example_stage": {
                   "pipeline": "deploy-example-customer-1",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -67,25 +48,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -98,9 +60,9 @@
             "display_order": 5,
             "group": "example",
             "materials": {
-               "deploy-example-customer-2-pipeline-complete": {
+               "deploy-example-customer-2-example_stage": {
                   "pipeline": "deploy-example-customer-2",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -113,25 +75,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -155,25 +98,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -197,25 +121,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }

--- a/test/testdata/goldens/pipedream/exclude-regions.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/exclude-regions.jsonnet_single-file.golden
@@ -5,9 +5,9 @@
          "display_order": 3,
          "group": "example",
          "materials": {
-            "deploy-example-s4s-pipeline-complete": {
+            "deploy-example-s4s-example_stage": {
                "pipeline": "deploy-example-s4s",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -20,25 +20,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -46,9 +27,9 @@
          "display_order": 4,
          "group": "example",
          "materials": {
-            "deploy-example-customer-1-pipeline-complete": {
+            "deploy-example-customer-1-example_stage": {
                "pipeline": "deploy-example-customer-1",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -61,25 +42,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -87,9 +49,9 @@
          "display_order": 5,
          "group": "example",
          "materials": {
-            "deploy-example-customer-2-pipeline-complete": {
+            "deploy-example-customer-2-example_stage": {
                "pipeline": "deploy-example-customer-2",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -102,25 +64,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -139,25 +82,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -176,25 +100,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       }

--- a/test/testdata/goldens/pipedream/minimal-config.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/minimal-config.jsonnet_output-files.golden
@@ -6,9 +6,9 @@
             "display_order": 4,
             "group": "example",
             "materials": {
-               "deploy-example-us-pipeline-complete": {
+               "deploy-example-us-example_stage": {
                   "pipeline": "deploy-example-us",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -21,25 +21,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -52,9 +33,9 @@
             "display_order": 5,
             "group": "example",
             "materials": {
-               "deploy-example-customer-1-pipeline-complete": {
+               "deploy-example-customer-1-example_stage": {
                   "pipeline": "deploy-example-customer-1",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -67,25 +48,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -98,9 +60,9 @@
             "display_order": 6,
             "group": "example",
             "materials": {
-               "deploy-example-customer-2-pipeline-complete": {
+               "deploy-example-customer-2-example_stage": {
                   "pipeline": "deploy-example-customer-2",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -113,25 +75,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -144,9 +87,9 @@
             "display_order": 7,
             "group": "example",
             "materials": {
-               "deploy-example-customer-3-pipeline-complete": {
+               "deploy-example-customer-3-example_stage": {
                   "pipeline": "deploy-example-customer-3",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -159,25 +102,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -201,25 +125,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -243,25 +148,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -285,25 +171,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -316,9 +183,9 @@
             "display_order": 3,
             "group": "example",
             "materials": {
-               "deploy-example-s4s-pipeline-complete": {
+               "deploy-example-s4s-example_stage": {
                   "pipeline": "deploy-example-s4s",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -331,25 +198,6 @@
             "stages": [
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }

--- a/test/testdata/goldens/pipedream/minimal-config.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/minimal-config.jsonnet_single-file.golden
@@ -5,9 +5,9 @@
          "display_order": 4,
          "group": "example",
          "materials": {
-            "deploy-example-us-pipeline-complete": {
+            "deploy-example-us-example_stage": {
                "pipeline": "deploy-example-us",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -20,25 +20,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -46,9 +27,9 @@
          "display_order": 5,
          "group": "example",
          "materials": {
-            "deploy-example-customer-1-pipeline-complete": {
+            "deploy-example-customer-1-example_stage": {
                "pipeline": "deploy-example-customer-1",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -61,25 +42,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -87,9 +49,9 @@
          "display_order": 6,
          "group": "example",
          "materials": {
-            "deploy-example-customer-2-pipeline-complete": {
+            "deploy-example-customer-2-example_stage": {
                "pipeline": "deploy-example-customer-2",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -102,25 +64,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -128,9 +71,9 @@
          "display_order": 7,
          "group": "example",
          "materials": {
-            "deploy-example-customer-3-pipeline-complete": {
+            "deploy-example-customer-3-example_stage": {
                "pipeline": "deploy-example-customer-3",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -143,25 +86,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -180,25 +104,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -217,25 +122,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -254,25 +140,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -280,9 +147,9 @@
          "display_order": 3,
          "group": "example",
          "materials": {
-            "deploy-example-s4s-pipeline-complete": {
+            "deploy-example-s4s-example_stage": {
                "pipeline": "deploy-example-s4s",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -295,25 +162,6 @@
          "stages": [
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       }

--- a/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
@@ -6,9 +6,9 @@
             "display_order": 4,
             "group": "example",
             "materials": {
-               "deploy-example-us-pipeline-complete": {
+               "deploy-example-us-example_stage": {
                   "pipeline": "deploy-example-us",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -54,25 +54,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -85,9 +66,9 @@
             "display_order": 5,
             "group": "example",
             "materials": {
-               "deploy-example-customer-1-pipeline-complete": {
+               "deploy-example-customer-1-example_stage": {
                   "pipeline": "deploy-example-customer-1",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -133,25 +114,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -164,9 +126,9 @@
             "display_order": 6,
             "group": "example",
             "materials": {
-               "deploy-example-customer-2-pipeline-complete": {
+               "deploy-example-customer-2-example_stage": {
                   "pipeline": "deploy-example-customer-2",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -212,25 +174,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -243,9 +186,9 @@
             "display_order": 7,
             "group": "example",
             "materials": {
-               "deploy-example-customer-3-pipeline-complete": {
+               "deploy-example-customer-3-example_stage": {
                   "pipeline": "deploy-example-customer-3",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -291,25 +234,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -322,10 +246,6 @@
             "display_order": 8,
             "group": "example",
             "materials": {
-               "deploy-example-pipeline-complete": {
-                  "pipeline": "deploy-example",
-                  "stage": "pipeline-complete"
-               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
@@ -370,25 +290,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -401,10 +302,6 @@
             "display_order": 9,
             "group": "example",
             "materials": {
-               "deploy-example-pipeline-complete": {
-                  "pipeline": "deploy-example",
-                  "stage": "pipeline-complete"
-               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
@@ -449,25 +346,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -480,10 +358,6 @@
             "display_order": 2,
             "group": "example",
             "materials": {
-               "deploy-example-pipeline-complete": {
-                  "pipeline": "deploy-example",
-                  "stage": "pipeline-complete"
-               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
@@ -528,25 +402,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -559,9 +414,9 @@
             "display_order": 3,
             "group": "example",
             "materials": {
-               "deploy-example-s4s-pipeline-complete": {
+               "deploy-example-s4s-example_stage": {
                   "pipeline": "deploy-example-s4s",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                },
                "example_repo": {
                   "branch": "master",
@@ -607,25 +462,6 @@
                },
                {
                   "example_stage": { }
-               },
-               {
-                  "pipeline-complete": {
-                     "approval": {
-                        "allow_only_on_success": true,
-                        "type": "success"
-                     },
-                     "jobs": {
-                        "pipeline-complete": {
-                           "tasks": [
-                              {
-                                 "exec": {
-                                    "command": true
-                                 }
-                              }
-                           ]
-                        }
-                     }
-                  }
                }
             ]
          }
@@ -684,9 +520,9 @@
             "group": "example",
             "lock_behavior": "unlockWhenFinished",
             "materials": {
-               "deploy-example-customer-4-pipeline-complete": {
+               "deploy-example-customer-4-example_stage": {
                   "pipeline": "deploy-example-customer-4",
-                  "stage": "pipeline-complete"
+                  "stage": "example_stage"
                }
             },
             "stages": [

--- a/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_single-file.golden
@@ -38,9 +38,9 @@
          "display_order": 4,
          "group": "example",
          "materials": {
-            "deploy-example-us-pipeline-complete": {
+            "deploy-example-us-example_stage": {
                "pipeline": "deploy-example-us",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -86,25 +86,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -112,9 +93,9 @@
          "display_order": 5,
          "group": "example",
          "materials": {
-            "deploy-example-customer-1-pipeline-complete": {
+            "deploy-example-customer-1-example_stage": {
                "pipeline": "deploy-example-customer-1",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -160,25 +141,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -186,9 +148,9 @@
          "display_order": 6,
          "group": "example",
          "materials": {
-            "deploy-example-customer-2-pipeline-complete": {
+            "deploy-example-customer-2-example_stage": {
                "pipeline": "deploy-example-customer-2",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -234,25 +196,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -260,9 +203,9 @@
          "display_order": 7,
          "group": "example",
          "materials": {
-            "deploy-example-customer-3-pipeline-complete": {
+            "deploy-example-customer-3-example_stage": {
                "pipeline": "deploy-example-customer-3",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -308,25 +251,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -334,10 +258,6 @@
          "display_order": 8,
          "group": "example",
          "materials": {
-            "deploy-example-pipeline-complete": {
-               "pipeline": "deploy-example",
-               "stage": "pipeline-complete"
-            },
             "example_repo": {
                "branch": "master",
                "destination": "example",
@@ -382,25 +302,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -408,10 +309,6 @@
          "display_order": 9,
          "group": "example",
          "materials": {
-            "deploy-example-pipeline-complete": {
-               "pipeline": "deploy-example",
-               "stage": "pipeline-complete"
-            },
             "example_repo": {
                "branch": "master",
                "destination": "example",
@@ -456,25 +353,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -482,10 +360,6 @@
          "display_order": 2,
          "group": "example",
          "materials": {
-            "deploy-example-pipeline-complete": {
-               "pipeline": "deploy-example",
-               "stage": "pipeline-complete"
-            },
             "example_repo": {
                "branch": "master",
                "destination": "example",
@@ -530,25 +404,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -556,9 +411,9 @@
          "display_order": 3,
          "group": "example",
          "materials": {
-            "deploy-example-s4s-pipeline-complete": {
+            "deploy-example-s4s-example_stage": {
                "pipeline": "deploy-example-s4s",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             },
             "example_repo": {
                "branch": "master",
@@ -604,25 +459,6 @@
             },
             {
                "example_stage": { }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
             }
          ]
       },
@@ -638,9 +474,9 @@
          "group": "example",
          "lock_behavior": "unlockWhenFinished",
          "materials": {
-            "deploy-example-customer-4-pipeline-complete": {
+            "deploy-example-customer-4-example_stage": {
                "pipeline": "deploy-example-customer-4",
-               "stage": "pipeline-complete"
+               "stage": "example_stage"
             }
          },
          "stages": [


### PR DESCRIPTION
Removing the pipeline-complete stage should avoid pipelines being locked after a rollback.

Another perk of this is that it's one less thing the pipelines have to run (it's a noop, but it still takes a little bit of time to schedule and bring up the agent).

Lastly - I pulled out the chain_pipelines to a function so it could be used by getsentry control regions that will be changed when needed.