### PR TITLE
Make gocd-pipelines functions consistent and re-usable

### DIFF
--- a/libs/gocd-pipelines.libsonnet
+++ b/libs/gocd-pipelines.libsonnet
@@ -41,8 +41,11 @@ local pipelines_to_files_object(pipelines) =
 // This is used to output all pipelines in a single file.
 local pipelines_to_object(pipelines) =
   {
-    [pipelines[i].name]: pipelines[i].pipeline
-    for i in std.range(0, std.length(pipelines) - 1)
+    format_version: 10,
+    pipelines: {
+      [pipelines[i].name]: pipelines[i].pipeline
+      for i in std.range(0, std.length(pipelines) - 1)
+    },
   };
 
 {

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -39,8 +39,9 @@ local pipeline_name(name, region=null) =
 local is_autodeploy(pipedream_config) =
   !std.objectHas(pipedream_config, 'auto_deploy') || pipedream_config.auto_deploy == true;
 
-// The "trigger pipeline" is a pipeline that doesn't do anything special,
-// but it serves as a nice way to start the pipedream for end users.
+// This function returns a "trigger pipeline", if configured for manual deploys.
+// The pipeline doesn't do anything special, but it serves as a nice way to
+// start the pipedream for end users.
 local pipedream_trigger_pipelines(pipedream_config) =
   local name = pipedream_config.name;
   local materials = pipedream_config.materials;

--- a/test/gocd-pipelines.js
+++ b/test/gocd-pipelines.js
@@ -1,0 +1,9 @@
+import test from 'ava';
+import {assert_testdata, get_fixtures} from './utils/testdata.js';
+
+const files = await get_fixtures('gocd-pipelines');
+for (const f of files) {
+  test(`render ${f}`, async t => {
+    await assert_testdata(t, f);
+  });
+}

--- a/test/testdata/fixtures/gocd-pipelines/multiple-files.jsonnet
+++ b/test/testdata/fixtures/gocd-pipelines/multiple-files.jsonnet
@@ -1,0 +1,18 @@
+local gocd_pipelines = import '../../../../libs/gocd-pipelines.libsonnet';
+
+gocd_pipelines.pipelines_to_files_object([
+  {
+    name: 'example-1',
+    pipeline: {
+      group: 'example-1',
+      materials: [],
+    },
+  },
+  {
+    name: 'example-2',
+    pipeline: {
+      group: 'example-2',
+      materials: [],
+    },
+  },
+])

--- a/test/testdata/fixtures/gocd-pipelines/single-file.jsonnet
+++ b/test/testdata/fixtures/gocd-pipelines/single-file.jsonnet
@@ -1,0 +1,18 @@
+local gocd_pipelines = import '../../../../libs/gocd-pipelines.libsonnet';
+
+gocd_pipelines.pipelines_to_object([
+  {
+    name: 'example-1',
+    pipeline: {
+      group: 'example-1',
+      materials: [],
+    },
+  },
+  {
+    name: 'example-2',
+    pipeline: {
+      group: 'example-2',
+      materials: [],
+    },
+  },
+])

--- a/test/testdata/goldens/gocd-pipelines/multiple-files.jsonnet_output-files.golden
+++ b/test/testdata/goldens/gocd-pipelines/multiple-files.jsonnet_output-files.golden
@@ -1,0 +1,20 @@
+{
+   "example-1.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "example-1": {
+            "group": "example-1",
+            "materials": [ ]
+         }
+      }
+   },
+   "example-2.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "example-2": {
+            "group": "example-2",
+            "materials": [ ]
+         }
+      }
+   }
+}

--- a/test/testdata/goldens/gocd-pipelines/single-file.jsonnet_output-files.golden
+++ b/test/testdata/goldens/gocd-pipelines/single-file.jsonnet_output-files.golden
@@ -1,0 +1,13 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "example-1": {
+         "group": "example-1",
+         "materials": [ ]
+      },
+      "example-2": {
+         "group": "example-2",
+         "materials": [ ]
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
@@ -467,7 +467,7 @@
          }
       }
    },
-   "example.yaml": {
+   "deploy-example.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example": {


### PR DESCRIPTION
I noticed an issue when trying to roll this out to getsentry.

The `pipelines_to_files_object` and `pipelines_to_object` were inconsistent in what they did, files_object would include `format: 10, pipelines: ...` to the output making it valid to GoCD while the `pipeliens_to_object` would just return the pipelines which is invalid.

This corrects that, making both of them output valid GoCD pipelines