### PR TITLE
Fix non-auto-deploy pipelines

### DIFF
--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -58,7 +58,6 @@ local pipedream_trigger_pipeline(pipedream_config) =
         group: name,
         display_order: 0,
         materials: materials,
-        [if std.objectHas(pipedream_config, 'environment_variables') then 'environment_variables' else null]: pipedream_config.environment_variables,
         lock_behavior: 'unlockWhenFinished',
         stages: [
           gocd_stages.basic('pipeline-complete', [gocd_tasks.noop], { approval: approval_type }),

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -42,7 +42,7 @@ local is_autodeploy(pipedream_config) =
 // This function returns a "trigger pipeline", if configured for manual deploys.
 // The pipeline doesn't do anything special, but it serves as a nice way to
 // start the pipedream for end users.
-local pipedream_trigger_pipelines(pipedream_config) =
+local pipedream_trigger_pipeline(pipedream_config) =
   local name = pipedream_config.name;
   local materials = pipedream_config.materials;
   local autodeploy = is_autodeploy(pipedream_config);
@@ -50,24 +50,23 @@ local pipedream_trigger_pipelines(pipedream_config) =
     'manual' else null;
 
   if autodeploy == true then
-    []
+    null
   else
-    [
-      {
-        name: pipeline_name(name),
-        pipeline: {
-          group: name,
-          display_order: 0,
-          materials: materials,
-          lock_behavior: 'unlockWhenFinished',
-          stages: [
-            gocd_stages.basic('pipeline-complete', [gocd_tasks.noop], { approval: approval_type }),
-          ],
-        },
+    {
+      name: pipeline_name(name),
+      pipeline: {
+        group: name,
+        display_order: 0,
+        materials: materials,
+        [if std.objectHas(pipedream_config, 'environment_variables') then 'environment_variables' else null]: pipedream_config.environment_variables,
+        lock_behavior: 'unlockWhenFinished',
+        stages: [
+          gocd_stages.basic('pipeline-complete', [gocd_tasks.noop], { approval: approval_type }),
+        ],
       },
-    ];
+    };
 
-local pipedream_rollback_pipelines(pipedream_config, final_pipeline) =
+local pipedream_rollback_pipeline(pipedream_config, final_pipeline) =
   if std.objectHas(pipedream_config, 'rollback') then
     local name = pipedream_config.name;
     local region_pipeline_names = std.map(function(r) pipeline_name(name, r), REGIONS);
@@ -79,64 +78,62 @@ local pipedream_rollback_pipelines(pipedream_config, final_pipeline) =
 
     local final_stage = gocd_pipelines.final_stage_name(final_pipeline);
 
-    [
-      {
-        name: 'rollback-' + name,
-        pipeline: {
-          group: name,
-          display_order: 1,
-          environment_variables: {
-            GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
-            ROLLBACK_MATERIAL_NAME: pipedream_config.rollback.material_name,
-            ROLLBACK_STAGE: pipedream_config.rollback.stage,
-            REGION_PIPELINE_FLAGS: region_pipeline_flags,
-            ALL_PIPELINE_FLAGS: all_pipeline_flags,
-          },
-          materials: {
-            [final_pipeline.name + '-' + final_stage]: {
-              pipeline: final_pipeline.name,
-              stage: final_stage,
-            },
-          },
-          lock_behavior: 'unlockWhenFinished',
-          stages: [
-            {
-              pause_pipelines: {
-                approval: {
-                  type: 'manual',
-                },
-                jobs: {
-                  rollback: {
-                    elastic_profile_id: pipedream_config.rollback.elastic_profile_id,
-                    tasks: [
-                      gocd_tasks.script(importstr './bash/pause-pipelines.sh'),
-                    ],
-                  },
-                },
-              },
-            },
-            {
-              start_rollback: {
-                jobs: {
-                  rollback: {
-                    elastic_profile_id: pipedream_config.rollback.elastic_profile_id,
-                    tasks: [
-                      gocd_tasks.script(importstr './bash/rollback.sh'),
-                    ],
-                  },
-                },
-              },
-            },
-          ],
+    {
+      name: 'rollback-' + name,
+      pipeline: {
+        group: name,
+        display_order: 1,
+        environment_variables: {
+          GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
+          ROLLBACK_MATERIAL_NAME: pipedream_config.rollback.material_name,
+          ROLLBACK_STAGE: pipedream_config.rollback.stage,
+          REGION_PIPELINE_FLAGS: region_pipeline_flags,
+          ALL_PIPELINE_FLAGS: all_pipeline_flags,
         },
+        materials: {
+          [final_pipeline.name + '-' + final_stage]: {
+            pipeline: final_pipeline.name,
+            stage: final_stage,
+          },
+        },
+        lock_behavior: 'unlockWhenFinished',
+        stages: [
+          {
+            pause_pipelines: {
+              approval: {
+                type: 'manual',
+              },
+              jobs: {
+                rollback: {
+                  elastic_profile_id: pipedream_config.rollback.elastic_profile_id,
+                  tasks: [
+                    gocd_tasks.script(importstr './bash/pause-pipelines.sh'),
+                  ],
+                },
+              },
+            },
+          },
+          {
+            start_rollback: {
+              jobs: {
+                rollback: {
+                  elastic_profile_id: pipedream_config.rollback.elastic_profile_id,
+                  tasks: [
+                    gocd_tasks.script(importstr './bash/rollback.sh'),
+                  ],
+                },
+              },
+            },
+          },
+        ],
       },
-    ]
+    }
   else
-    [];
+    null;
 
 // generate_region_pipeline will call the pipeline callback function, and then
 // name the pipeline, add an upstream material, and append a final stage.
-local generate_region_pipeline(pipedream_config, regions_to_chain, region, weight, pipeline_fn) =
+local generate_region_pipeline(pipedream_config, region, weight, pipeline_fn) =
   // Get previous region's pipeline name
   local service_name = pipedream_config.name;
 
@@ -167,15 +164,29 @@ local generate_region_pipeline(pipedream_config, regions_to_chain, region, weigh
 
 // get_service_pipelines iterates over each region and generates the pipeline
 // for each region.
-local get_service_pipelines(pipedream_config, pipeline_fn, regions, regions_to_chain, display_offset) =
+local get_service_pipelines(pipedream_config, pipeline_fn, regions, display_offset) =
   [
     {
       name: pipeline_name(pipedream_config.name, regions[i]),
-      pipeline: generate_region_pipeline(pipedream_config, regions_to_chain, regions[i], display_offset + i, pipeline_fn),
+      pipeline: generate_region_pipeline(pipedream_config, regions[i], display_offset + i, pipeline_fn),
     }
     for i in std.range(0, std.length(regions) - 1)
   ];
 
+local pipeline_to_array(pipeline) =
+  if pipeline == null then [] else [pipeline];
+
+local add_trigger_material(should_add, trigger_pipeline) =
+  if trigger_pipeline != null && should_add then {
+    pipeline+: {
+      materials+: {
+        [trigger_pipeline.name + '-' + gocd_pipelines.final_stage_name(trigger_pipeline)]: {
+          pipeline: trigger_pipeline.name,
+          stage: gocd_pipelines.final_stage_name(trigger_pipeline),
+        },
+      },
+    },
+  } else {};
 
 {
   // render will generate the trigger pipeline and all the region pipelines.
@@ -188,13 +199,17 @@ local get_service_pipelines(pipedream_config, pipeline_fn, regions, regions_to_c
       function(r) !std.objectHas(pipedream_config, 'exclude_regions') || std.length(std.find(r, pipedream_config.exclude_regions)) == 0,
       TEST_REGIONS,
     );
-    local trigger_pipelines = pipedream_trigger_pipelines(pipedream_config);
-    local unchained_pipelines = get_service_pipelines(pipedream_config, pipeline_fn, regions_to_render, regions_to_render, 2);
+    local trigger_pipeline = pipedream_trigger_pipeline(pipedream_config);
+    local unchained_pipelines = get_service_pipelines(pipedream_config, pipeline_fn, regions_to_render, 2);
     local service_pipelines = gocd_pipelines.chain_pipelines(unchained_pipelines);
-    local test_pipelines = get_service_pipelines(pipedream_config, pipeline_fn, test_regions_to_render, [], std.length(regions_to_render) + 2);
-    local rollback_pipelines = pipedream_rollback_pipelines(pipedream_config, service_pipelines[std.length(service_pipelines) - 1]);
+    local test_pipelines = get_service_pipelines(pipedream_config, pipeline_fn, test_regions_to_render, std.length(regions_to_render) + 2);
+    local rollback_pipeline = pipedream_rollback_pipeline(pipedream_config, service_pipelines[std.length(service_pipelines) - 1]);
 
-    local all_pipelines = trigger_pipelines + rollback_pipelines + service_pipelines + test_pipelines;
+
+    local all_pipelines = pipeline_to_array(trigger_pipeline) +
+                          pipeline_to_array(rollback_pipeline) +
+                          std.mapWithIndex(function(i, v) v + add_trigger_material(i == 0, trigger_pipeline), service_pipelines) +
+                          std.mapWithIndex(function(i, v) v + add_trigger_material(true, trigger_pipeline), test_pipelines);
 
     if std.extVar('output-files') then
       gocd_pipelines.pipelines_to_files_object(all_pipelines)

--- a/test/pipedream.js
+++ b/test/pipedream.js
@@ -1,13 +1,96 @@
 import test from 'ava';
-import {assert_testdata, get_fixtures} from './utils/testdata.js';
+import {assert_testdata, assert_gocd_structure, get_fixtures, render_fixture} from './utils/testdata.js';
 
 const files = await get_fixtures('pipedream');
 for (const f of files) {
   test(`render ${f} as multiple files`, async t => {
     await assert_testdata(t, f, true);
+    await assert_gocd_structure(t, f, true);
   });
 
   test(`render ${f} as a single file`, async t => {
     await assert_testdata(t, f, false);
+    await assert_gocd_structure(t, f, true);
   });
 }
+
+test(`ensure manual deploys is expected structure`, async t => {
+  const got = await render_fixture('pipedream/no-autodeploy.jsonnet', false);
+
+  t.deepEqual(Object.keys(got), ['format_version', 'pipelines']);
+  t.truthy(got.pipelines['deploy-example']);
+  t.truthy(got.pipelines['deploy-example-s4s']);
+  t.truthy(got.pipelines['deploy-example-customer-5']);
+
+  // Ensure the trigger has the right initial material
+  const trigger = got.pipelines['deploy-example'];
+  t.deepEqual(trigger.materials, {
+    init_repo: {
+      branch: 'master',
+      destination: 'init',
+      git: 'git@github.com:getsentry/init.git',
+      shallow_clone: true,
+    },
+  });
+
+  // Ensure s4s depends on the trigger material
+  const s4s = got.pipelines['deploy-example-s4s'];
+  t.deepEqual(s4s.materials, {
+    'deploy-example-pipeline-complete': {
+      pipeline: 'deploy-example',
+      stage: 'pipeline-complete',
+    },
+    'example_repo': {
+      branch: 'master',
+      destination: 'example',
+      git: 'git@github.com:getsentry/example.git',
+      shallow_clone: true,
+    },
+  });
+
+  // Ensure a test region depends on the trigger material
+  const c5 = got.pipelines['deploy-example-customer-5'];
+  t.deepEqual(c5.materials, {
+    'deploy-example-pipeline-complete': {
+      pipeline: 'deploy-example',
+      stage: 'pipeline-complete',
+    },
+    'example_repo': {
+      branch: 'master',
+      destination: 'example',
+      git: 'git@github.com:getsentry/example.git',
+      shallow_clone: true,
+    },
+  });
+});
+
+test(`ensure auto deploys is expected structure`, async t => {
+  const got = await render_fixture('pipedream/autodeploy.jsonnet', false);
+
+  t.deepEqual(Object.keys(got), ['format_version', 'pipelines']);
+  t.falsy(got.pipelines['deploy-example']);
+  t.truthy(got.pipelines['deploy-example-s4s']);
+  t.truthy(got.pipelines['deploy-example-customer-5']);
+
+  // Ensure s4s has just the repo material
+  const s4s = got.pipelines['deploy-example-s4s'];
+  t.deepEqual(s4s.materials, {
+    'example_repo': {
+      branch: 'master',
+      destination: 'example',
+      git: 'git@github.com:getsentry/example.git',
+      shallow_clone: true,
+    },
+  });
+
+  // Ensure a test region has just the repo material
+  const c5 = got.pipelines['deploy-example-customer-5'];
+  t.deepEqual(c5.materials, {
+    'example_repo': {
+      branch: 'master',
+      destination: 'example',
+      git: 'git@github.com:getsentry/example.git',
+      shallow_clone: true,
+    },
+  });
+});

--- a/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_output-files.golden
@@ -246,6 +246,10 @@
             "display_order": 8,
             "group": "example",
             "materials": {
+               "deploy-example-pipeline-complete": {
+                  "pipeline": "deploy-example",
+                  "stage": "pipeline-complete"
+               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
@@ -302,6 +306,10 @@
             "display_order": 9,
             "group": "example",
             "materials": {
+               "deploy-example-pipeline-complete": {
+                  "pipeline": "deploy-example",
+                  "stage": "pipeline-complete"
+               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",
@@ -358,6 +366,10 @@
             "display_order": 2,
             "group": "example",
             "materials": {
+               "deploy-example-pipeline-complete": {
+                  "pipeline": "deploy-example",
+                  "stage": "pipeline-complete"
+               },
                "example_repo": {
                   "branch": "master",
                   "destination": "example",

--- a/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/no-autodeploy.jsonnet_single-file.golden
@@ -258,6 +258,10 @@
          "display_order": 8,
          "group": "example",
          "materials": {
+            "deploy-example-pipeline-complete": {
+               "pipeline": "deploy-example",
+               "stage": "pipeline-complete"
+            },
             "example_repo": {
                "branch": "master",
                "destination": "example",
@@ -309,6 +313,10 @@
          "display_order": 9,
          "group": "example",
          "materials": {
+            "deploy-example-pipeline-complete": {
+               "pipeline": "deploy-example",
+               "stage": "pipeline-complete"
+            },
             "example_repo": {
                "branch": "master",
                "destination": "example",
@@ -360,6 +368,10 @@
          "display_order": 2,
          "group": "example",
          "materials": {
+            "deploy-example-pipeline-complete": {
+               "pipeline": "deploy-example",
+               "stage": "pipeline-complete"
+            },
             "example_repo": {
                "branch": "master",
                "destination": "example",


### PR DESCRIPTION
When I removed the pipeline-complete stage I inadvertently removed the trigger material for non-auto-deploy pipedreams.

I've fixed that and added some more helpful tests that explicitly check for structure of auto-deploy and non-auto-deploy pipedreams.