### PR TITLE
Adding TRIGGERED_BY env var to enhance the pause message

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You'll need [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler
 
 ```sh
 jb init
-jb install https://github.com/getsentry/gocd-jsonnet.git/libs@v2.10.1
+jb install https://github.com/getsentry/gocd-jsonnet.git/libs@v2.10.2
 ```
 
 ## Build

--- a/libs/bash/pause-pipelines.sh
+++ b/libs/bash/pause-pipelines.sh
@@ -6,10 +6,17 @@ if [[ "${ALL_PIPELINE_FLAGS:-}" ]]; then
   set -- $ALL_PIPELINE_FLAGS
 fi
 
-# Set the pause message to the value of the PAUSE_MESSAGE environment variable or use the default message
-PAUSE_MESSAGE="${PAUSE_MESSAGE:-This pipeline is being rolled back, please check with team before un-pausing.}"
+# The user that triggered the rollback
+TRIGGERED_BY="${TRIGGERED_BY:-}"
+
+pause_message='This pipeline is being rolled back, please check with team before un-pausing.'
+
+# Include triggered by in the pause message if it is not empty
+if [ -n "$TRIGGERED_BY" ]; then
+  pause_message="$pause_message Triggered by: $TRIGGERED_BY"
+fi
 
 # Pause all pipelines in the pipedream
 gocd-pause-and-cancel-pipelines \
-  --pause-message="$PAUSE_MESSAGE" \
+  --pause-message="$pause_message" \
   "$@"

--- a/libs/bash/rollback.sh
+++ b/libs/bash/rollback.sh
@@ -6,6 +6,16 @@ if [[ "${REGION_PIPELINE_FLAGS:-}" ]]; then
   set -- $REGION_PIPELINE_FLAGS
 fi
 
+# The user that triggered the rollback
+TRIGGERED_BY="${TRIGGERED_BY:-}"
+
+pause_message='This pipeline was rolled back, please check with team before un-pausing.'
+
+# Include triggered by in the pause message if it is not empty
+if [ -n "$TRIGGERED_BY" ]; then
+  pause_message="$pause_message Triggered by: $TRIGGERED_BY"
+fi
+
 # Get sha from the given pipeline run to deploy to all pipedream pipelines.
 sha=$(gocd-sha-for-pipeline --material-name="${ROLLBACK_MATERIAL_NAME}")
 
@@ -15,5 +25,5 @@ gocd-emergency-deploy \
   --material-name="${ROLLBACK_MATERIAL_NAME}" \
   --commit-sha="${sha}" \
   --deploy-stage="${ROLLBACK_STAGE}" \
-  --pause-message="This pipeline was rolled back, please check with team before un-pausing." \
+  --pause-message="$pause_message" \
   "$@"

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -105,6 +105,7 @@ local pipedream_rollback_pipeline(pipedream_config, service_pipelines, trigger_p
           ROLLBACK_STAGE: pipedream_config.rollback.stage,
           REGION_PIPELINE_FLAGS: region_pipeline_flags,
           ALL_PIPELINE_FLAGS: all_pipeline_flags,
+          TRIGGERED_BY: '',
         },
         materials: {
           [final_pipeline.name + '-' + final_stage]: {

--- a/test/pipedream.js
+++ b/test/pipedream.js
@@ -112,6 +112,7 @@ test("ensure auto deploys is expected structure", async (t) => {
       "--pipeline=deploy-example-s4s --pipeline=deploy-example-de --pipeline=deploy-example-us --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-3 --pipeline=deploy-example-customer-4",
     ROLLBACK_MATERIAL_NAME: "example_repo",
     ROLLBACK_STAGE: "example_stage",
+    TRIGGERED_BY: "",
   });
   t.deepEqual(r["materials"], {
     "deploy-example-customer-4-pipeline-complete": {


### PR DESCRIPTION
Adding a more proper means of tracking who rolled back a pipeline that enables us to keep the different messages for pause-pipelines and rollback stages. Additionally, in order for this to work properly, GoCD requires that the environment variable exist, even if empty.