### PR TITLE
ref(config): Adding auto-excluded control region

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You'll need [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler
 
 ```sh
 jb init
-jb install https://github.com/getsentry/gocd-jsonnet.git/libs@v2.12.0
+jb install https://github.com/getsentry/gocd-jsonnet.git/libs@v2.14.0
 ```
 
 ## Build

--- a/libs/getsentry.libsonnet
+++ b/libs/getsentry.libsonnet
@@ -8,6 +8,8 @@
     's4s',
     'de',
     'us',
+    // 'control' is excluded by default and must be explicitly included
+    'control',
     'customer-1',
     'customer-2',
     'customer-4',

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -241,6 +241,7 @@ local pipeline_to_array(pipeline) =
 {
   // render will generate the trigger pipeline and all the region pipelines.
   render(pipedream_config, pipeline_fn)::
+    // Regions that are excluded by default and must be explicitly included
     local default_excluded_regions = ['control'];
 
     local is_excluded_region = function(region, config)
@@ -255,8 +256,7 @@ local pipeline_to_array(pipeline) =
     local should_include_region = function(region, config)
       !is_excluded_region(region, config) && (!is_default_excluded_region(region) || is_included_region(region, config));
 
-    // Filter out any regions that are listed in the `exclude_regions`
-    // attribute.
+    // Filter out any regions that are listed in the `exclude_regions` attribute.
     local regions_to_render = std.filter(
       function(region) should_include_region(region, pipedream_config),
       getsentry.prod_regions,

--- a/test/testdata/fixtures/pipedream/include-regions-no-autodeploy.jsonnet
+++ b/test/testdata/fixtures/pipedream/include-regions-no-autodeploy.jsonnet
@@ -1,0 +1,41 @@
+local pipedream = import '../../../../libs/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'example',
+  auto_deploy: false,
+  include_regions: ['control'],
+  exclude_regions: ['s4s', 'us'],
+  materials: {
+    init_repo: {
+      git: 'git@github.com:getsentry/init.git',
+      branch: 'master',
+      destination: 'init',
+    },
+  },
+  rollback: {
+    material_name: 'example_repo',
+    stage: 'example_stage',
+    elastic_profile_id: 'example_profile',
+  },
+};
+
+local sample = {
+  pipeline(region):: {
+    region: region,
+    materials: {
+      example_repo: {
+        git: 'git@github.com:getsentry/example.git',
+        shallow_clone: true,
+        branch: 'master',
+        destination: 'example',
+      },
+    },
+    stages: [
+      {
+        example_stage: {},
+      },
+    ],
+  },
+};
+
+pipedream.render(pipedream_config, sample.pipeline)

--- a/test/testdata/fixtures/pipedream/include-regions.jsonnet
+++ b/test/testdata/fixtures/pipedream/include-regions.jsonnet
@@ -1,0 +1,40 @@
+local pipedream = import '../../../../libs/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'example',
+  include_regions: ['control'],
+  exclude_regions: ['s4s', 'us'],
+  materials: {
+    init_repo: {
+      git: 'git@github.com:getsentry/init.git',
+      branch: 'master',
+      destination: 'init',
+    },
+  },
+  rollback: {
+    material_name: 'example_repo',
+    stage: 'example_stage',
+    elastic_profile_id: 'example_profile',
+  },
+};
+
+local sample = {
+  pipeline(region):: {
+    region: region,
+    materials: {
+      example_repo: {
+        git: 'git@github.com:getsentry/example.git',
+        shallow_clone: true,
+        branch: 'master',
+        destination: 'example',
+      },
+    },
+    stages: [
+      {
+        example_stage: {},
+      },
+    ],
+  },
+};
+
+pipedream.render(pipedream_config, sample.pipeline)

--- a/test/testdata/goldens/getsentry/regions.jsonnet_output-files.golden
+++ b/test/testdata/goldens/getsentry/regions.jsonnet_output-files.golden
@@ -3,6 +3,7 @@
       "s4s",
       "de",
       "us",
+      "control",
       "customer-1",
       "customer-2",
       "customer-4",

--- a/test/testdata/goldens/pipedream/include-regions.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/include-regions.jsonnet_output-files.golden
@@ -1,0 +1,281 @@
+{
+  "deploy-example-control.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-control": {
+            "display_order": 3,
+            "group": "example",
+            "materials": {
+               "deploy-example-de-pipeline-complete": {
+                  "pipeline": "deploy-example-de",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git",
+                  "shallow_clone": true
+               }
+            },
+            "region": "control",
+            "stages": [
+               {
+                  "example_stage": { }
+               },
+               {
+                  "pipeline-complete": {
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-customer-1.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-customer-1": {
+            "display_order": 4,
+            "group": "example",
+            "materials": {
+               "deploy-example-control-pipeline-complete": {
+                  "pipeline": "deploy-example-control",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git",
+                  "shallow_clone": true
+               }
+            },
+            "region": "customer-1",
+            "stages": [
+               {
+                  "example_stage": { }
+               },
+               {
+                  "pipeline-complete": {
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-customer-2.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-customer-2": {
+            "display_order": 5,
+            "group": "example",
+            "materials": {
+               "deploy-example-customer-1-pipeline-complete": {
+                  "pipeline": "deploy-example-customer-1",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git",
+                  "shallow_clone": true
+               }
+            },
+            "region": "customer-2",
+            "stages": [
+               {
+                  "example_stage": { }
+               },
+               {
+                  "pipeline-complete": {
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-customer-4.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-customer-4": {
+            "display_order": 6,
+            "group": "example",
+            "materials": {
+               "deploy-example-customer-2-pipeline-complete": {
+                  "pipeline": "deploy-example-customer-2",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git",
+                  "shallow_clone": true
+               }
+            },
+            "region": "customer-4",
+            "stages": [
+               {
+                  "example_stage": { }
+               },
+               {
+                  "pipeline-complete": {
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-de.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-de": {
+            "display_order": 2,
+            "group": "example",
+            "materials": {
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git",
+                  "shallow_clone": true
+               }
+            },
+            "region": "de",
+            "stages": [
+               {
+                  "example_stage": { }
+               },
+               {
+                  "pipeline-complete": {
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "rollback-example.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "rollback-example": {
+            "display_order": 1,
+            "environment_variables": {
+               "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-de --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-4",
+               "GOCD_ACCESS_TOKEN": "{{SECRET:[devinfra][gocd_access_token]}}",
+               "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-de --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-4",
+               "ROLLBACK_MATERIAL_NAME": "example_repo",
+               "ROLLBACK_STAGE": "example_stage"
+            },
+            "group": "example",
+            "lock_behavior": "unlockWhenFinished",
+            "materials": {
+               "deploy-example-customer-4-pipeline-complete": {
+                  "pipeline": "deploy-example-customer-4",
+                  "stage": "pipeline-complete"
+               }
+            },
+            "stages": [
+               {
+                  "pause_pipelines": {
+                     "approval": {
+                        "type": "manual"
+                     },
+                     "jobs": {
+                        "rollback": {
+                           "elastic_profile_id": "example_profile",
+                           "tasks": [
+                              {
+                                 "script": "##!/bin/bash\n\n## Note: $ALL_PIPELINE_FLAGS has no quoting, for word expansion\n## shellcheck disable=SC2086\nif [[ \"${ALL_PIPELINE_FLAGS:-}\" ]]; then\n  set -- $ALL_PIPELINE_FLAGS\nfi\n\n## Pause all pipelines in the pipedream\ngocd-pause-and-cancel-pipelines \\\n  --pause-message=\"This pipeline is being rolled back, please check with team before un-pausing.\" \\\n  \"$@\"\n"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "start_rollback": {
+                     "jobs": {
+                        "rollback": {
+                           "elastic_profile_id": "example_profile",
+                           "tasks": [
+                              {
+                                 "script": "##!/bin/bash\n\n## Note: $REGION_PIPELINE_FLAGS has no quoting, for word expansion\n## shellcheck disable=SC2086\nif [[ \"${REGION_PIPELINE_FLAGS:-}\" ]]; then\n  set -- $REGION_PIPELINE_FLAGS\nfi\n\n## Get sha from the given pipeline run to deploy to all pipedream pipelines.\nsha=$(gocd-sha-for-pipeline --material-name=\"${ROLLBACK_MATERIAL_NAME}\")\n\necho \"📑 Rolling back to sha: ${sha}\"\n\ngocd-emergency-deploy \\\n  --material-name=\"${ROLLBACK_MATERIAL_NAME}\" \\\n  --commit-sha=\"${sha}\" \\\n  --deploy-stage=\"${ROLLBACK_STAGE}\" \\\n  --pause-message=\"This pipeline was rolled back, please check with team before un-pausing.\" \\\n  \"$@\"\n"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "incident_resolved": {
+                     "approval": {
+                        "type": "manual"
+                     },
+                     "jobs": {
+                        "rollback": {
+                           "elastic_profile_id": "example_profile",
+                           "tasks": [
+                              {
+                                 "script": "##!/bin/bash\n\n## Note: $ALL_PIPELINE_FLAGS has no quoting, for word expansion\n## shellcheck disable=SC2086\nif [[ \"${ALL_PIPELINE_FLAGS:-}\" ]]; then\n  set -- $ALL_PIPELINE_FLAGS\nfi\n\n## Unpause and unlock all pipelines in the pipedream\ngocd-unpause-and-unlock-pipelines \\\n  \"$@\"\n"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/include-regions.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/include-regions.jsonnet_single-file.golden
@@ -1,0 +1,254 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "deploy-example-control": {
+         "display_order": 3,
+         "group": "example",
+         "materials": {
+            "deploy-example-de-pipeline-complete": {
+               "pipeline": "deploy-example-de",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "control",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-customer-1": {
+         "display_order": 4,
+         "group": "example",
+         "materials": {
+            "deploy-example-control-pipeline-complete": {
+               "pipeline": "deploy-example-control",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "customer-1",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-customer-2": {
+         "display_order": 5,
+         "group": "example",
+         "materials": {
+            "deploy-example-customer-1-pipeline-complete": {
+               "pipeline": "deploy-example-customer-1",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "customer-2",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-customer-4": {
+         "display_order": 6,
+         "group": "example",
+         "materials": {
+            "deploy-example-customer-2-pipeline-complete": {
+               "pipeline": "deploy-example-customer-2",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "customer-4",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-de": {
+         "display_order": 2,
+         "group": "example",
+         "materials": {
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git",
+               "shallow_clone": true
+            }
+         },
+         "region": "de",
+         "stages": [
+            {
+               "example_stage": { }
+            },
+            {
+               "pipeline-complete": {
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "rollback-example": {
+         "display_order": 1,
+         "environment_variables": {
+            "ALL_PIPELINE_FLAGS": "--pipeline=deploy-example-de --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-4",
+            "GOCD_ACCESS_TOKEN": "{{SECRET:[devinfra][gocd_access_token]}}",
+            "REGION_PIPELINE_FLAGS": "--pipeline=deploy-example-de --pipeline=deploy-example-customer-1 --pipeline=deploy-example-customer-2 --pipeline=deploy-example-customer-4",
+            "ROLLBACK_MATERIAL_NAME": "example_repo",
+            "ROLLBACK_STAGE": "example_stage"
+         },
+         "group": "example",
+         "lock_behavior": "unlockWhenFinished",
+         "materials": {
+            "deploy-example-customer-4-pipeline-complete": {
+               "pipeline": "deploy-example-customer-4",
+               "stage": "pipeline-complete"
+            }
+         },
+         "stages": [
+            {
+               "pause_pipelines": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "rollback": {
+                        "elastic_profile_id": "example_profile",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n## Note: $ALL_PIPELINE_FLAGS has no quoting, for word expansion\n## shellcheck disable=SC2086\nif [[ \"${ALL_PIPELINE_FLAGS:-}\" ]]; then\n  set -- $ALL_PIPELINE_FLAGS\nfi\n\n## Pause all pipelines in the pipedream\ngocd-pause-and-cancel-pipelines \\\n  --pause-message=\"This pipeline is being rolled back, please check with team before un-pausing.\" \\\n  \"$@\"\n"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "start_rollback": {
+                  "jobs": {
+                     "rollback": {
+                        "elastic_profile_id": "example_profile",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n## Note: $REGION_PIPELINE_FLAGS has no quoting, for word expansion\n## shellcheck disable=SC2086\nif [[ \"${REGION_PIPELINE_FLAGS:-}\" ]]; then\n  set -- $REGION_PIPELINE_FLAGS\nfi\n\n## Get sha from the given pipeline run to deploy to all pipedream pipelines.\nsha=$(gocd-sha-for-pipeline --material-name=\"${ROLLBACK_MATERIAL_NAME}\")\n\necho \"📑 Rolling back to sha: ${sha}\"\n\ngocd-emergency-deploy \\\n  --material-name=\"${ROLLBACK_MATERIAL_NAME}\" \\\n  --commit-sha=\"${sha}\" \\\n  --deploy-stage=\"${ROLLBACK_STAGE}\" \\\n  --pause-message=\"This pipeline was rolled back, please check with team before un-pausing.\" \\\n  \"$@\"\n"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "incident_resolved": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "rollback": {
+                        "elastic_profile_id": "example_profile",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n## Note: $ALL_PIPELINE_FLAGS has no quoting, for word expansion\n## shellcheck disable=SC2086\nif [[ \"${ALL_PIPELINE_FLAGS:-}\" ]]; then\n  set -- $ALL_PIPELINE_FLAGS\nfi\n\n## Unpause and unlock all pipelines in the pipedream\ngocd-unpause-and-unlock-pipelines \\\n  \"$@\"\n"
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}


### PR DESCRIPTION
Introducing a mechanism for include-able regions, which are excluded by default and must be explicitly included. The first use of this new mechanism is the control region for getsentry-backend, which deploys control after US and before STs, thus its placement in the prod_regions list. Although the control region applies to only one service, its integration with pipedream (gocd-jsonnet) allows for coordinated rollbacks with other regions and proper placement among other regions, deploying before STs and after US.