### PR TITLE
ref(control): Create fake region for control in us

### DIFF
--- a/libs/getsentry.libsonnet
+++ b/libs/getsentry.libsonnet
@@ -10,6 +10,7 @@
     'us',
     // 'control' is excluded by default and must be explicitly included
     'control',
+    'prod-control',
     // 'snty-tools' is excluded by default and must be explicitly included
     'snty-tools',
     'customer-1',

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -241,7 +241,7 @@ local pipeline_to_array(pipeline) =
   // render will generate the trigger pipeline and all the region pipelines.
   render(pipedream_config, pipeline_fn, parallel=false)::
     // Regions that are excluded by default and must be explicitly included
-    local default_excluded_regions = ['control', 'snty-tools'];
+    local default_excluded_regions = ['control', 'prod-control', 'snty-tools'];
 
     local is_excluded_region = function(region, config)
       std.objectHas(config, 'exclude_regions') && std.length(std.find(region, config.exclude_regions)) > 0;

--- a/test/testdata/goldens/getsentry/regions.jsonnet_output-files.golden
+++ b/test/testdata/goldens/getsentry/regions.jsonnet_output-files.golden
@@ -4,6 +4,7 @@
       "de",
       "us",
       "control",
+      "prod-control",
       "snty-tools",
       "customer-1",
       "customer-2",


### PR DESCRIPTION
Add another alias for control in us.
Why stupid name? 
here https://github.com/getsentry/devinfra-deployment-service/blob/5c730aea8697945854db469d29b7840155588b69/gocd_agent/scripts/scripts/regions/region-configs/prod-control.json