### PR TITLE
fix(pipedream): don't double-suffix region in already-suffixed job names

### DIFF
--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -387,7 +387,9 @@ local generate_group_pipeline(pipedream_config, pipeline_fn, group, display_orde
         local stage_jobs = if region_stage != null then get_stage_jobs(region_stage) else {};
 
         acc + {
-          [job_name + '-' + region]: (
+          // Skip the suffix if job_name already ends with '-{region}' (pattern
+          // used by ops/k8s.libsonnet) so we don't get 'diff-region-region'.
+          [if std.endsWith(job_name, '-' + region) then job_name else job_name + '-' + region]: (
             local job = stage_jobs[job_name];
             local job_env = if std.objectHas(job, 'environment_variables') then job.environment_variables else {};
             local merged_env = region_specific_env + job_env;

--- a/test/testdata/fixtures/pipedream/region-suffixed-jobs.jsonnet
+++ b/test/testdata/fixtures/pipedream/region-suffixed-jobs.jsonnet
@@ -1,0 +1,63 @@
+local pipedream = import '../../../../libs/pipedream.libsonnet';
+
+// Exercises the pattern used by ops/gocd/templates/libs/k8s.libsonnet, where
+// pipeline_fn outputs job names already containing the region (e.g.
+// `'diff-' + region`) and downstream stages reference those names via fetch
+// tasks. Without the dedup, transform_stage would double-suffix the names
+// (e.g. `diff-customer-1-customer-1`) and break the fetch references.
+local pipedream_config = {
+  name: 'example',
+  auto_deploy: true,
+  exclude_regions: ['de', 'us'],
+};
+
+local sample = {
+  pipeline(region):: {
+    materials: {
+      example_repo: {
+        git: 'git@github.com:getsentry/example.git',
+        branch: 'master',
+        destination: 'example',
+      },
+    },
+    stages: [
+      {
+        diff: {
+          jobs: {
+            ['diff-' + region]: {
+              elastic_profile_id: 'example',
+              tasks: [
+                { script: './diff.sh --region=' + region },
+              ],
+              artifacts: [
+                { build: { source: 'result', destination: 'output' } },
+              ],
+            },
+          },
+        },
+      },
+      {
+        apply: {
+          jobs: {
+            ['apply-' + region]: {
+              elastic_profile_id: 'example',
+              tasks: [
+                {
+                  fetch: {
+                    stage: 'diff',
+                    job: 'diff-' + region,
+                    source: 'output',
+                    destination: 'artifacts',
+                  },
+                },
+                { script: './apply.sh --region=' + region },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
+pipedream.render(pipedream_config, sample.pipeline)

--- a/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_output-files.golden
@@ -1,0 +1,264 @@
+{
+   "deploy-example-s4s2.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-s4s2": {
+            "display_order": 2,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "s4s2"
+            },
+            "group": "example",
+            "materials": {
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "diff": {
+                     "jobs": {
+                        "diff-s4s2": {
+                           "artifacts": [
+                              {
+                                 "build": {
+                                    "destination": "output",
+                                    "source": "result"
+                                 }
+                              }
+                           ],
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=s4s2"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "apply": {
+                     "jobs": {
+                        "apply-s4s2": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "fetch": {
+                                    "destination": "artifacts",
+                                    "job": "diff-s4s2",
+                                    "source": "output",
+                                    "stage": "diff"
+                                 }
+                              },
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=s4s2"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-st.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-st": {
+            "display_order": 3,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "customer-1,customer-2,customer-4,customer-7"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-s4s2-pipeline-complete": {
+                  "pipeline": "deploy-example-s4s2",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "diff": {
+                     "jobs": {
+                        "diff-customer-1": {
+                           "artifacts": [
+                              {
+                                 "build": {
+                                    "destination": "output",
+                                    "source": "result"
+                                 }
+                              }
+                           ],
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-1"
+                              }
+                           ]
+                        },
+                        "diff-customer-2": {
+                           "artifacts": [
+                              {
+                                 "build": {
+                                    "destination": "output",
+                                    "source": "result"
+                                 }
+                              }
+                           ],
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-2"
+                              }
+                           ]
+                        },
+                        "diff-customer-4": {
+                           "artifacts": [
+                              {
+                                 "build": {
+                                    "destination": "output",
+                                    "source": "result"
+                                 }
+                              }
+                           ],
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-4"
+                              }
+                           ]
+                        },
+                        "diff-customer-7": {
+                           "artifacts": [
+                              {
+                                 "build": {
+                                    "destination": "output",
+                                    "source": "result"
+                                 }
+                              }
+                           ],
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-7"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "apply": {
+                     "jobs": {
+                        "apply-customer-1": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "fetch": {
+                                    "destination": "artifacts",
+                                    "job": "diff-customer-1",
+                                    "source": "output",
+                                    "stage": "diff"
+                                 }
+                              },
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-1"
+                              }
+                           ]
+                        },
+                        "apply-customer-2": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "fetch": {
+                                    "destination": "artifacts",
+                                    "job": "diff-customer-2",
+                                    "source": "output",
+                                    "stage": "diff"
+                                 }
+                              },
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-2"
+                              }
+                           ]
+                        },
+                        "apply-customer-4": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "fetch": {
+                                    "destination": "artifacts",
+                                    "job": "diff-customer-4",
+                                    "source": "output",
+                                    "stage": "diff"
+                                 }
+                              },
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-4"
+                              }
+                           ]
+                        },
+                        "apply-customer-7": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "fetch": {
+                                    "destination": "artifacts",
+                                    "job": "diff-customer-7",
+                                    "source": "output",
+                                    "stage": "diff"
+                                 }
+                              },
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-7"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_single-file.golden
@@ -1,0 +1,257 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "deploy-example-s4s2": {
+         "display_order": 2,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "s4s2"
+         },
+         "group": "example",
+         "materials": {
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "diff": {
+                  "jobs": {
+                     "diff-s4s2": {
+                        "artifacts": [
+                           {
+                              "build": {
+                                 "destination": "output",
+                                 "source": "result"
+                              }
+                           }
+                        ],
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=s4s2"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "apply": {
+                  "jobs": {
+                     "apply-s4s2": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "fetch": {
+                                 "destination": "artifacts",
+                                 "job": "diff-s4s2",
+                                 "source": "output",
+                                 "stage": "diff"
+                              }
+                           },
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=s4s2"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-st": {
+         "display_order": 3,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "customer-1,customer-2,customer-4,customer-7"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-s4s2-pipeline-complete": {
+               "pipeline": "deploy-example-s4s2",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "diff": {
+                  "jobs": {
+                     "diff-customer-1": {
+                        "artifacts": [
+                           {
+                              "build": {
+                                 "destination": "output",
+                                 "source": "result"
+                              }
+                           }
+                        ],
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-1"
+                           }
+                        ]
+                     },
+                     "diff-customer-2": {
+                        "artifacts": [
+                           {
+                              "build": {
+                                 "destination": "output",
+                                 "source": "result"
+                              }
+                           }
+                        ],
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-2"
+                           }
+                        ]
+                     },
+                     "diff-customer-4": {
+                        "artifacts": [
+                           {
+                              "build": {
+                                 "destination": "output",
+                                 "source": "result"
+                              }
+                           }
+                        ],
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-4"
+                           }
+                        ]
+                     },
+                     "diff-customer-7": {
+                        "artifacts": [
+                           {
+                              "build": {
+                                 "destination": "output",
+                                 "source": "result"
+                              }
+                           }
+                        ],
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=customer-7"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "apply": {
+                  "jobs": {
+                     "apply-customer-1": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "fetch": {
+                                 "destination": "artifacts",
+                                 "job": "diff-customer-1",
+                                 "source": "output",
+                                 "stage": "diff"
+                              }
+                           },
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-1"
+                           }
+                        ]
+                     },
+                     "apply-customer-2": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "fetch": {
+                                 "destination": "artifacts",
+                                 "job": "diff-customer-2",
+                                 "source": "output",
+                                 "stage": "diff"
+                              }
+                           },
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-2"
+                           }
+                        ]
+                     },
+                     "apply-customer-4": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "fetch": {
+                                 "destination": "artifacts",
+                                 "job": "diff-customer-4",
+                                 "source": "output",
+                                 "stage": "diff"
+                              }
+                           },
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-4"
+                           }
+                        ]
+                     },
+                     "apply-customer-7": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "fetch": {
+                                 "destination": "artifacts",
+                                 "job": "diff-customer-7",
+                                 "source": "output",
+                                 "stage": "diff"
+                              }
+                           },
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=customer-7"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}


### PR DESCRIPTION
One line fix, rest is test fixtures.

Once ops bumps to v3.0.0, k8s pipelines that use `k8s.libsonnet` helpers (snuba-k8s, getsentry-k8s, taskbroker-k8s, etc.) fail GoCD validation:

> "deploy-snuba-k8s-st :: apply-primary :: apply-customer-2-customer-2" tries to fetch artifact from job "deploy-snuba-k8s-st :: diff :: diff-customer-2" which does not exist.

The k8s helpers output job names already containing the region (`['diff-' + region]: k8s.diff_job(...)`), and downstream stages reference those names by interpolating region into the fetch task (`job: 'diff-' + region`). v3's `transform_stage` adds another `-{region}` suffix during aggregation, so the rendered job becomes `diff-customer-1-customer-1` while the sibling fetch still looks for `diff-customer-1`.

Skip the suffix when the original job name already ends with `-{region}`. Backward-compatible for non-pre-suffixed services (every existing fixture's behavior is unchanged), single-line conditional in the aggregation. Adds a fixture (`region-suffixed-jobs.jsonnet`) covering the pre-suffixed pattern so this regression can't sneak back.