### PR TITLE
fix(pipedream): skip auto-suffix for single-region groups

### DIFF
--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -387,9 +387,13 @@ local generate_group_pipeline(pipedream_config, pipeline_fn, group, display_orde
         local stage_jobs = if region_stage != null then get_stage_jobs(region_stage) else {};
 
         acc + {
-          // Skip the suffix if job_name already ends with '-{region}' (pattern
-          // used by ops/k8s.libsonnet) so we don't get 'diff-region-region'.
-          [if std.endsWith(job_name, '-' + region) then job_name else job_name + '-' + region]: (
+          // Skip the suffix when there's nothing to disambiguate: a
+          // single-region group (one pipeline_fn call, names already unique)
+          // or a job already keyed by region (would yield 'diff-region-region').
+          [
+          local skip_suffix = std.length(regions) == 1 || std.endsWith(job_name, '-' + region);
+          if skip_suffix then job_name else job_name + '-' + region
+          ]: (
             local job = stage_jobs[job_name];
             local job_env = if std.objectHas(job, 'environment_variables') then job.environment_variables else {};
             local merged_env = region_specific_env + job_env;

--- a/test/pipedream.js
+++ b/test/pipedream.js
@@ -49,7 +49,9 @@ test("single-region group has one job", async (t) => {
 
   const de = got.pipelines["deploy-example-de"];
   const deJobs = Object.keys(de.stages[0].deploy.jobs);
-  t.deepEqual(deJobs, ["deploy-de"]);
+  // Single-region groups skip the auto-suffix since pipeline_fn is called
+  // once and the user-emitted job names are already unique.
+  t.deepEqual(deJobs, ["deploy"]);
 });
 
 test("serial mode: pipelines chain sequentially", async (t) => {

--- a/test/testdata/fixtures/pipedream/single-region-multi-cell.jsonnet
+++ b/test/testdata/fixtures/pipedream/single-region-multi-cell.jsonnet
@@ -1,0 +1,71 @@
+local pipedream = import '../../../../libs/pipedream.libsonnet';
+
+// Exercises the pattern used by ops/gocd/templates/pipelines/uptime-checker-k8s
+// and vector-uc-k8s, where pipeline_fn is called once per single-region group
+// (e.g. region='de') but expands internally to multiple cells (e.g.
+// 'de-west-de', 'de-west-nl'). Jobs are keyed by cell name, and downstream
+// stages fetch artifacts using those cell-keyed names. Without the
+// single-region skip, transform_stage would append the group region
+// (e.g. 'diff-de-west-nl-de') and break the cell-keyed fetch references.
+local pipedream_config = {
+  name: 'example',
+  auto_deploy: true,
+  exclude_regions: ['us', 's4s2', 'customer-1', 'customer-2', 'customer-4', 'customer-7'],
+};
+
+local cells_for(region) = {
+  de: ['de-west-de', 'de-west-nl'],
+}[region];
+
+local sample = {
+  pipeline(region):: {
+    materials: {
+      example_repo: {
+        git: 'git@github.com:getsentry/example.git',
+        branch: 'master',
+        destination: 'example',
+      },
+    },
+    stages: [
+      {
+        diff: {
+          jobs: {
+            ['diff-' + cell]: {
+              elastic_profile_id: 'example',
+              tasks: [
+                { script: './diff.sh --cell=' + cell },
+              ],
+              artifacts: [
+                { build: { source: 'result', destination: 'output' } },
+              ],
+            }
+            for cell in cells_for(region)
+          },
+        },
+      },
+      {
+        apply: {
+          jobs: {
+            ['apply-' + cell]: {
+              elastic_profile_id: 'example',
+              tasks: [
+                {
+                  fetch: {
+                    stage: 'diff',
+                    job: 'diff-' + cell,
+                    source: 'output',
+                    destination: 'artifacts',
+                  },
+                },
+                { script: './apply.sh --cell=' + cell },
+              ],
+            }
+            for cell in cells_for(region)
+          },
+        },
+      },
+    ],
+  },
+};
+
+pipedream.render(pipedream_config, sample.pipeline)

--- a/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -74,7 +74,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -208,7 +208,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_single-file.golden
@@ -22,7 +22,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -68,7 +68,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -192,7 +192,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/basic-manual.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/basic-manual.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -78,7 +78,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -212,7 +212,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/basic-manual.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/basic-manual.jsonnet_single-file.golden
@@ -55,7 +55,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -105,7 +105,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -229,7 +229,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/different-stages-per-region.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/different-stages-per-region.jsonnet_output-files.golden
@@ -22,7 +22,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "tasks": [
                               {
                                  "exec": {
@@ -40,7 +40,7 @@
                {
                   "verify": {
                      "jobs": {
-                        "verify-de": {
+                        "verify": {
                            "tasks": [
                               {
                                  "exec": {
@@ -94,7 +94,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "tasks": [
                               {
                                  "exec": {
@@ -112,7 +112,7 @@
                {
                   "verify": {
                      "jobs": {
-                        "verify-s4s2": {
+                        "verify": {
                            "tasks": [
                               {
                                  "exec": {
@@ -306,7 +306,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "tasks": [
                               {
                                  "exec": {
@@ -324,7 +324,7 @@
                {
                   "verify": {
                      "jobs": {
-                        "verify-us": {
+                        "verify": {
                            "tasks": [
                               {
                                  "exec": {

--- a/test/testdata/goldens/pipedream/different-stages-per-region.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/different-stages-per-region.jsonnet_single-file.golden
@@ -21,7 +21,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "tasks": [
                            {
                               "exec": {
@@ -39,7 +39,7 @@
             {
                "verify": {
                   "jobs": {
-                     "verify-de": {
+                     "verify": {
                         "tasks": [
                            {
                               "exec": {
@@ -88,7 +88,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "tasks": [
                            {
                               "exec": {
@@ -106,7 +106,7 @@
             {
                "verify": {
                   "jobs": {
-                     "verify-s4s2": {
+                     "verify": {
                         "tasks": [
                            {
                               "exec": {
@@ -290,7 +290,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "tasks": [
                            {
                               "exec": {
@@ -308,7 +308,7 @@
             {
                "verify": {
                   "jobs": {
-                     "verify-us": {
+                     "verify": {
                         "tasks": [
                            {
                               "exec": {

--- a/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_output-files.golden
@@ -24,7 +24,7 @@
                         "STAGE_VAR": "stage-s4s2"
                      },
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "environment_variables": {
                               "JOB_VAR": "job-s4s2",
                               "SHARED_VAR_JOB": "from-job"

--- a/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_single-file.golden
@@ -23,7 +23,7 @@
                      "STAGE_VAR": "stage-s4s2"
                   },
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "environment_variables": {
                            "JOB_VAR": "job-s4s2",
                            "SHARED_VAR_JOB": "from-job"

--- a/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -74,7 +74,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -129,7 +129,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_single-file.golden
@@ -22,7 +22,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -68,7 +68,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -118,7 +118,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/exclude-region.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/exclude-region.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -74,7 +74,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -200,7 +200,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/exclude-region.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/exclude-region.jsonnet_single-file.golden
@@ -22,7 +22,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -68,7 +68,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -184,7 +184,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-control": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -78,7 +78,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -129,7 +129,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -263,7 +263,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_single-file.golden
@@ -22,7 +22,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-control": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -72,7 +72,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -118,7 +118,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -242,7 +242,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/multi-region-group.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/multi-region-group.jsonnet_output-files.golden
@@ -19,7 +19,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/multi-region-group.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/multi-region-group.jsonnet_single-file.golden
@@ -18,7 +18,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/parallel-mode.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/parallel-mode.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -78,7 +78,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -212,7 +212,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/parallel-mode.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/parallel-mode.jsonnet_single-file.golden
@@ -55,7 +55,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -105,7 +105,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -229,7 +229,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -74,7 +74,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -208,7 +208,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_single-file.golden
@@ -22,7 +22,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -68,7 +68,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -192,7 +192,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/rollback.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/rollback.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-de": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -74,7 +74,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
@@ -208,7 +208,7 @@
                {
                   "deploy": {
                      "jobs": {
-                        "deploy-us": {
+                        "deploy": {
                            "elastic_profile_id": "example",
                            "tasks": [
                               {

--- a/test/testdata/goldens/pipedream/rollback.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/rollback.jsonnet_single-file.golden
@@ -22,7 +22,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-de": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -68,7 +68,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
@@ -192,7 +192,7 @@
             {
                "deploy": {
                   "jobs": {
-                     "deploy-us": {
+                     "deploy": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {

--- a/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_output-files.golden
@@ -1,0 +1,115 @@
+{
+   "deploy-example-de.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-de": {
+            "display_order": 2,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "de"
+            },
+            "group": "example",
+            "materials": {
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "diff": {
+                     "jobs": {
+                        "diff-de-west-de": {
+                           "artifacts": [
+                              {
+                                 "build": {
+                                    "destination": "output",
+                                    "source": "result"
+                                 }
+                              }
+                           ],
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-de"
+                              }
+                           ]
+                        },
+                        "diff-de-west-nl": {
+                           "artifacts": [
+                              {
+                                 "build": {
+                                    "destination": "output",
+                                    "source": "result"
+                                 }
+                              }
+                           ],
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-nl"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "apply": {
+                     "jobs": {
+                        "apply-de-west-de": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "fetch": {
+                                    "destination": "artifacts",
+                                    "job": "diff-de-west-de",
+                                    "source": "output",
+                                    "stage": "diff"
+                                 }
+                              },
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-de"
+                              }
+                           ]
+                        },
+                        "apply-de-west-nl": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "fetch": {
+                                    "destination": "artifacts",
+                                    "job": "diff-de-west-nl",
+                                    "source": "output",
+                                    "stage": "diff"
+                                 }
+                              },
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-nl"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_single-file.golden
@@ -1,0 +1,113 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "deploy-example-de": {
+         "display_order": 2,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "de"
+         },
+         "group": "example",
+         "materials": {
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "diff": {
+                  "jobs": {
+                     "diff-de-west-de": {
+                        "artifacts": [
+                           {
+                              "build": {
+                                 "destination": "output",
+                                 "source": "result"
+                              }
+                           }
+                        ],
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-de"
+                           }
+                        ]
+                     },
+                     "diff-de-west-nl": {
+                        "artifacts": [
+                           {
+                              "build": {
+                                 "destination": "output",
+                                 "source": "result"
+                              }
+                           }
+                        ],
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-nl"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "apply": {
+                  "jobs": {
+                     "apply-de-west-de": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "fetch": {
+                                 "destination": "artifacts",
+                                 "job": "diff-de-west-de",
+                                 "source": "output",
+                                 "stage": "diff"
+                              }
+                           },
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-de"
+                           }
+                        ]
+                     },
+                     "apply-de-west-nl": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "fetch": {
+                                 "destination": "artifacts",
+                                 "job": "diff-de-west-nl",
+                                 "source": "output",
+                                 "stage": "diff"
+                              }
+                           },
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-nl"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/stage-props.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/stage-props.jsonnet_output-files.golden
@@ -22,7 +22,7 @@
                      },
                      "fetch_materials": true,
                      "jobs": {
-                        "deploy-s4s2": {
+                        "deploy": {
                            "tasks": [
                               {
                                  "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"

--- a/test/testdata/goldens/pipedream/stage-props.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/stage-props.jsonnet_single-file.golden
@@ -21,7 +21,7 @@
                   },
                   "fetch_materials": true,
                   "jobs": {
-                     "deploy-s4s2": {
+                     "deploy": {
                         "tasks": [
                            {
                               "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"


### PR DESCRIPTION
After ops bumped to v3.0.1, GoCD threw 20 validation errors on `deploy-uptime-checker-k8s-{de,us}` and `deploy-vector-uc-k8s-{de,us}`. Their pipelines emit jobs keyed by physical cell (`apply-canary-de-west-nl`, `diff-us-east-sc`, ...) inside a single-region group, so pipedream's auto-suffix turned them into `apply-canary-de-west-nl-de` while downstream apply jobs still fetched `apply-canary-de-west-nl`. The fetches couldn't resolve and the whole config repo failed to load.

Fundamentally, when a group has only one region there's no aggregation across regions, so appending the region suffix to job names doesn't disambiguate anything - it just decorates names that the consumer didn't ask for. This adds a `length == 1` skip alongside the existing `endsWith` check so single-region groups leave job names alone. Multi-region groups (the `st` shape) are unchanged.

New fixture mirrors the uptime-checker pattern. Existing goldens regenerated where single-region group jobs shed the redundant suffix (e.g. `deploy-de` -> `deploy` in `deploy-foo-de`); confirmed no v3 service in production references those post-aggregation names externally.