### PR TITLE
fix(pipedream): skip gate for single-region groups

### DIFF
--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -31,15 +31,7 @@ local gocd_tasks = import './gocd-tasks.libsonnet';
 local pipeline_name(name, region=null) =
   if region != null then 'deploy-' + name + '-' + region else 'deploy-' + name;
 
-// POSIX-shell preamble injected at the top of every script task in a group
-// pipeline's region-keyed jobs. The renderer sets PIPEDREAM_GROUP_REGIONS to
-// the full list of regions in the group, so by default every region's job
-// runs. To target a subset (e.g. one region) override PIPEDREAM_GROUP_REGIONS
-// in GoCD's "Trigger with options" — jobs whose SENTRY_REGION isn't in the
-// (possibly subsetted) list exit 0 cleanly.
-//
-// Stays POSIX (single-bracket [, no [[) so it works under dash, which is the
-// /bin/sh on most Linux GoCD agents and would silently no-op `[[` expressions.
+// POSIX gate (no `[[`, for dash GoCD agents) letting an operator deploy a region subset of a group via PIPEDREAM_GROUP_REGIONS in "Trigger with options".
 local deploy_target_gate = |||
   if [ -n "${PIPEDREAM_GROUP_REGIONS:-}" ] && [ -n "${SENTRY_REGION:-}" ]; then
     case ",${PIPEDREAM_GROUP_REGIONS}," in
@@ -417,7 +409,10 @@ local generate_group_pipeline(pipedream_config, pipeline_fn, group, display_orde
             local job = stage_jobs[job_name];
             local job_env = if std.objectHas(job, 'environment_variables') then job.environment_variables else {};
             local merged_env = region_specific_env + job_env;
-            local job_tasks = if std.objectHas(job, 'tasks') then [wrap_task(t) for t in job.tasks] else null;
+            // Single-region groups skip the gate (see deploy_target_gate).
+            local job_tasks = if std.objectHas(job, 'tasks') then
+              (if std.length(regions) == 1 then job.tasks else [wrap_task(t) for t in job.tasks])
+            else null;
             local gated_job = if job_tasks != null then job { tasks: job_tasks } else job;
             if std.length(std.objectFields(merged_env)) > 0 then
               gated_job { environment_variables: merged_env }

--- a/test/testdata/fixtures/pipedream/single-region-multi-cell.jsonnet
+++ b/test/testdata/fixtures/pipedream/single-region-multi-cell.jsonnet
@@ -1,12 +1,9 @@
 local pipedream = import '../../../../libs/pipedream.libsonnet';
 
-// Exercises the pattern used by ops/gocd/templates/pipelines/uptime-checker-k8s
-// and vector-uc-k8s, where pipeline_fn is called once per single-region group
-// (e.g. region='de') but expands internally to multiple cells (e.g.
-// 'de-west-de', 'de-west-nl'). Jobs are keyed by cell name, and downstream
-// stages fetch artifacts using those cell-keyed names. Without the
-// single-region skip, transform_stage would append the group region
-// (e.g. 'diff-de-west-nl-de') and break the cell-keyed fetch references.
+// Mirrors the uptime-checker-k8s / vector-uc-k8s shape: a single-region group
+// whose pipeline_fn fans out to multiple cell-keyed jobs that override
+// SENTRY_REGION per cell. Validates that pipedream skips both the suffix and
+// the gate for single-region groups.
 local pipedream_config = {
   name: 'example',
   auto_deploy: true,
@@ -32,6 +29,7 @@ local sample = {
           jobs: {
             ['diff-' + cell]: {
               elastic_profile_id: 'example',
+              environment_variables: { SENTRY_REGION: cell },
               tasks: [
                 { script: './diff.sh --cell=' + cell },
               ],
@@ -48,6 +46,7 @@ local sample = {
           jobs: {
             ['apply-' + cell]: {
               elastic_profile_id: 'example',
+              environment_variables: { SENTRY_REGION: cell },
               tasks: [
                 {
                   fetch: {

--- a/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -78,7 +78,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -212,7 +212,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -267,7 +267,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/basic-autodeploy.jsonnet_single-file.golden
@@ -26,7 +26,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -72,7 +72,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -196,7 +196,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -246,7 +246,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/basic-manual.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/basic-manual.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -82,7 +82,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -216,7 +216,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -271,7 +271,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/basic-manual.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/basic-manual.jsonnet_single-file.golden
@@ -59,7 +59,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -109,7 +109,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -233,7 +233,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -283,7 +283,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_output-files.golden
@@ -31,7 +31,7 @@
                            },
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -196,7 +196,7 @@
                            },
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/env-vars-precedence.jsonnet_single-file.golden
@@ -30,7 +30,7 @@
                         },
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -185,7 +185,7 @@
                         },
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -78,7 +78,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -133,7 +133,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -188,7 +188,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/exclude-entire-group.jsonnet_single-file.golden
@@ -26,7 +26,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -72,7 +72,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -122,7 +122,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -172,7 +172,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/exclude-region.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/exclude-region.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -78,7 +78,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -204,7 +204,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -259,7 +259,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/exclude-region.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/exclude-region.jsonnet_single-file.golden
@@ -26,7 +26,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -72,7 +72,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -188,7 +188,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -238,7 +238,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=control"
+                                 "script": "./deploy.sh --region=control"
                               }
                            ]
                         }
@@ -82,7 +82,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -133,7 +133,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -267,7 +267,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -322,7 +322,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/include-default-excluded.jsonnet_single-file.golden
@@ -26,7 +26,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=control"
+                              "script": "./deploy.sh --region=control"
                            }
                         ]
                      }
@@ -76,7 +76,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -122,7 +122,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -246,7 +246,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -296,7 +296,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/multi-region-group.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/multi-region-group.jsonnet_output-files.golden
@@ -23,7 +23,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -157,7 +157,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/multi-region-group.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/multi-region-group.jsonnet_single-file.golden
@@ -22,7 +22,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -146,7 +146,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/parallel-mode.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/parallel-mode.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -82,7 +82,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -216,7 +216,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -271,7 +271,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/parallel-mode.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/parallel-mode.jsonnet_single-file.golden
@@ -59,7 +59,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -109,7 +109,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -233,7 +233,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -283,7 +283,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_output-files.golden
@@ -31,7 +31,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=s4s2"
+                                 "script": "./diff.sh --region=s4s2"
                               }
                            ]
                         }
@@ -53,7 +53,7 @@
                                  }
                               },
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=s4s2"
+                                 "script": "./apply.sh --region=s4s2"
                               }
                            ]
                         }
@@ -297,7 +297,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=us2"
+                                 "script": "./diff.sh --region=us2"
                               }
                            ]
                         }
@@ -319,7 +319,7 @@
                                  }
                               },
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=us2"
+                                 "script": "./apply.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/region-suffixed-jobs.jsonnet_single-file.golden
@@ -30,7 +30,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=s4s2"
+                              "script": "./diff.sh --region=s4s2"
                            }
                         ]
                      }
@@ -52,7 +52,7 @@
                               }
                            },
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=s4s2"
+                              "script": "./apply.sh --region=s4s2"
                            }
                         ]
                      }
@@ -286,7 +286,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --region=us2"
+                              "script": "./diff.sh --region=us2"
                            }
                         ]
                      }
@@ -308,7 +308,7 @@
                               }
                            },
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --region=us2"
+                              "script": "./apply.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/rollback-final-pipeline-override.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/rollback-final-pipeline-override.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -78,7 +78,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -212,7 +212,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -267,7 +267,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/rollback-final-pipeline-override.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/rollback-final-pipeline-override.jsonnet_single-file.golden
@@ -26,7 +26,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -72,7 +72,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -196,7 +196,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -246,7 +246,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -78,7 +78,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -212,7 +212,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -267,7 +267,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/rollback-final-stage-override.jsonnet_single-file.golden
@@ -26,7 +26,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -72,7 +72,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -196,7 +196,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -246,7 +246,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/rollback.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/rollback.jsonnet_output-files.golden
@@ -27,7 +27,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                                 "script": "./deploy.sh --region=de"
                               }
                            ]
                         }
@@ -78,7 +78,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -212,7 +212,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                                 "script": "./deploy.sh --region=us"
                               }
                            ]
                         }
@@ -267,7 +267,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/rollback.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/rollback.jsonnet_single-file.golden
@@ -26,7 +26,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=de"
+                              "script": "./deploy.sh --region=de"
                            }
                         ]
                      }
@@ -72,7 +72,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -196,7 +196,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us"
+                              "script": "./deploy.sh --region=us"
                            }
                         ]
                      }
@@ -246,7 +246,7 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_output-files.golden
@@ -29,9 +29,12 @@
                               }
                            ],
                            "elastic_profile_id": "example",
+                           "environment_variables": {
+                              "SENTRY_REGION": "de-west-de"
+                           },
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-de"
+                                 "script": "./diff.sh --cell=de-west-de"
                               }
                            ]
                         },
@@ -45,9 +48,12 @@
                               }
                            ],
                            "elastic_profile_id": "example",
+                           "environment_variables": {
+                              "SENTRY_REGION": "de-west-nl"
+                           },
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-nl"
+                                 "script": "./diff.sh --cell=de-west-nl"
                               }
                            ]
                         }
@@ -59,6 +65,9 @@
                      "jobs": {
                         "apply-de-west-de": {
                            "elastic_profile_id": "example",
+                           "environment_variables": {
+                              "SENTRY_REGION": "de-west-de"
+                           },
                            "tasks": [
                               {
                                  "fetch": {
@@ -69,12 +78,15 @@
                                  }
                               },
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-de"
+                                 "script": "./apply.sh --cell=de-west-de"
                               }
                            ]
                         },
                         "apply-de-west-nl": {
                            "elastic_profile_id": "example",
+                           "environment_variables": {
+                              "SENTRY_REGION": "de-west-nl"
+                           },
                            "tasks": [
                               {
                                  "fetch": {
@@ -85,7 +97,7 @@
                                  }
                               },
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-nl"
+                                 "script": "./apply.sh --cell=de-west-nl"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/single-region-multi-cell.jsonnet_single-file.golden
@@ -28,9 +28,12 @@
                            }
                         ],
                         "elastic_profile_id": "example",
+                        "environment_variables": {
+                           "SENTRY_REGION": "de-west-de"
+                        },
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-de"
+                              "script": "./diff.sh --cell=de-west-de"
                            }
                         ]
                      },
@@ -44,9 +47,12 @@
                            }
                         ],
                         "elastic_profile_id": "example",
+                        "environment_variables": {
+                           "SENTRY_REGION": "de-west-nl"
+                        },
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./diff.sh --cell=de-west-nl"
+                              "script": "./diff.sh --cell=de-west-nl"
                            }
                         ]
                      }
@@ -58,6 +64,9 @@
                   "jobs": {
                      "apply-de-west-de": {
                         "elastic_profile_id": "example",
+                        "environment_variables": {
+                           "SENTRY_REGION": "de-west-de"
+                        },
                         "tasks": [
                            {
                               "fetch": {
@@ -68,12 +77,15 @@
                               }
                            },
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-de"
+                              "script": "./apply.sh --cell=de-west-de"
                            }
                         ]
                      },
                      "apply-de-west-nl": {
                         "elastic_profile_id": "example",
+                        "environment_variables": {
+                           "SENTRY_REGION": "de-west-nl"
+                        },
                         "tasks": [
                            {
                               "fetch": {
@@ -84,7 +96,7 @@
                               }
                            },
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./apply.sh --cell=de-west-nl"
+                              "script": "./apply.sh --cell=de-west-nl"
                            }
                         ]
                      }

--- a/test/testdata/goldens/pipedream/stage-props.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/stage-props.jsonnet_output-files.golden
@@ -25,7 +25,7 @@
                         "deploy": {
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                                 "script": "./deploy.sh --region=s4s2"
                               }
                            ]
                         }
@@ -160,7 +160,7 @@
                         "deploy": {
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                                 "script": "./deploy.sh --region=us2"
                               }
                            ]
                         }

--- a/test/testdata/goldens/pipedream/stage-props.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/stage-props.jsonnet_single-file.golden
@@ -24,7 +24,7 @@
                      "deploy": {
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=s4s2"
+                              "script": "./deploy.sh --region=s4s2"
                            }
                         ]
                      }
@@ -149,7 +149,7 @@
                      "deploy": {
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=us2"
+                              "script": "./deploy.sh --region=us2"
                            }
                         ]
                      }


### PR DESCRIPTION
`uptime-checker` deploys are triggering our region-skip gate. Their groups have one region, but `pipeline_fn` fans out to physical cells that override `SENTRY_REGION` per cell, so the region gate compares a cell name (`us-east-sc`) against `PIPEDREAM_GROUP_REGIONS=us` and exits 0 on every cell.

There's nothing to subset in a single-region group, so we skip the gate there. Multi-region groups (`st`) keep it.

The `single-region-multi-cell` fixture now overrides `SENTRY_REGION` per cell so it covers this.
