### PR TITLE
feat(pipedream): add edge pipeline group for edge/default and the 15 PoPs

### DIFF
--- a/libs/getsentry.libsonnet
+++ b/libs/getsentry.libsonnet
@@ -2,8 +2,40 @@
 * sentry-specific helpers
 */
 
+// The edge region and its 15 points-of-presence clusters. The PoPs are
+// modelled as pseudo-regions (like the uptime clusters) so each one gets its
+// own diff/apply job; `edge` itself is the sentry-edge `primary` cluster.
+// Every entry here is default-excluded in pipedream.libsonnet, so a service
+// only deploys to edge if it opts in via include_regions.
+//
+// Kept as a file-level local rather than a field so that `pipeline_groups.edge`
+// does not depend on `self` — pipeline_groups gets copied into other objects,
+// which would rebind `self` and break the reference.
+local edge_regions = [
+  'edge',
+  'edge-pop-au',
+  'edge-pop-br',
+  'edge-pop-ca',
+  'edge-pop-de',
+  'edge-pop-fi',
+  'edge-pop-in',
+  'edge-pop-jp',
+  'edge-pop-nl',
+  'edge-pop-or',
+  'edge-pop-qa',
+  'edge-pop-rr',
+  'edge-pop-sc',
+  'edge-pop-sg',
+  'edge-pop-tx',
+  'edge-pop-va',
+];
+
 {
-  group_order: ['s4s2', 'de', 'us', 'us2', 'control', 'prod-control', 'snty-tools', 'st'],
+  edge_regions:: edge_regions,
+
+  // `edge` trails the SaaS regions: these are ingest-path clusters, so they
+  // should only move after the regions they front are known good.
+  group_order: ['s4s2', 'de', 'us', 'us2', 'control', 'prod-control', 'snty-tools', 'edge', 'st'],
   // Empty for now — add future test groups here
   test_group_order: [],
   // These groupings consist of user facing deployments
@@ -15,6 +47,7 @@
     control: ['control'],
     'prod-control': ['prod-control'],
     'snty-tools': ['snty-tools'],
+    edge: edge_regions,
     st: ['customer-1', 'customer-2', 'customer-7'],
   },
   // Test groups will deploy in parallel to the groups above

--- a/libs/getsentry.libsonnet
+++ b/libs/getsentry.libsonnet
@@ -12,11 +12,11 @@ local edge_region = 'edge';
 // the gate for them.
 local edge_pop_canary_regions = ['edge-pop-rr'];
 
-// The remaining PoPs. They share a group so they deploy as parallel jobs: there
-// is no meaningful order between them, and alphabetical order in particular
-// implies a sequencing that does not exist. Adding a PoP here needs no ordering
-// decision.
-local edge_pop_regions = [
+// The PoPs the canary gates. They share a group so they deploy as parallel jobs:
+// there is no meaningful order between them, and alphabetical order in
+// particular implies a sequencing that does not exist. Adding a PoP here needs
+// no ordering decision.
+local edge_pop_gated_regions = [
   'edge-pop-au',
   'edge-pop-br',
   'edge-pop-ca',
@@ -42,12 +42,17 @@ local edge_pop_regions = [
 // Kept as file-level locals rather than fields so that pipeline_groups does not
 // depend on `self` -- pipeline_groups gets copied into other objects, which
 // would rebind `self` and break the reference.
-local edge_all_pop_regions = edge_pop_canary_regions + edge_pop_regions;
-local edge_regions = [edge_region] + edge_all_pop_regions;
+local edge_pop_regions = edge_pop_canary_regions + edge_pop_gated_regions;
+local edge_regions = [edge_region] + edge_pop_regions;
 
 {
   edge_regions:: edge_regions,
-  edge_pop_regions:: edge_all_pop_regions,
+
+  // All 15 PoPs, canary included -- deliberately not the same set as the
+  // `edge-pop` group, which holds only the 14 the canary gates. A service that
+  // runs on the PoPs wants all 15 in its include_regions; pipedream then splits
+  // them across the canary and gated groups on its behalf.
+  edge_pop_regions:: edge_pop_regions,
 
   // The edge groups trail the SaaS regions: these are ingest-path clusters, so
   // they should only move after the regions they front are known good. Within
@@ -78,7 +83,7 @@ local edge_regions = [edge_region] + edge_all_pop_regions;
     'snty-tools': ['snty-tools'],
     edge: [edge_region],
     'edge-pop-canary': edge_pop_canary_regions,
-    'edge-pop': edge_pop_regions,
+    'edge-pop': edge_pop_gated_regions,
     st: ['customer-1', 'customer-2', 'customer-7'],
   },
   // Test groups will deploy in parallel to the groups above

--- a/libs/getsentry.libsonnet
+++ b/libs/getsentry.libsonnet
@@ -2,17 +2,21 @@
 * sentry-specific helpers
 */
 
-// The edge region and its 15 points-of-presence clusters. The PoPs are
-// modelled as pseudo-regions (like the uptime clusters) so each one gets its
-// own diff/apply job; `edge` itself is the sentry-edge `primary` cluster.
-// Every entry here is default-excluded in pipedream.libsonnet, so a service
-// only deploys to edge if it opts in via include_regions.
-//
-// Kept as a file-level local rather than a field so that `pipeline_groups.edge`
-// does not depend on `self` — pipeline_groups gets copied into other objects,
-// which would rebind `self` and break the reference.
-local edge_regions = [
-  'edge',
+// `edge` is the sentry-edge `primary` cluster. It is an ordinary region cluster
+// and gets an ordinary single-region group, exactly like us/de/s4s2/control.
+local edge_region = 'edge';
+
+// pop-rr is the canary cluster for the PoP fleet. The PoPs have no in-cluster
+// canary deployments the way the SaaS regions do -- one whole cluster plays that
+// role instead -- so it deploys as its own group, ahead of the rest, and acts as
+// the gate for them.
+local edge_pop_canary_regions = ['edge-pop-rr'];
+
+// The remaining PoPs. They share a group so they deploy as parallel jobs: there
+// is no meaningful order between them, and alphabetical order in particular
+// implies a sequencing that does not exist. Adding a PoP here needs no ordering
+// decision.
+local edge_pop_regions = [
   'edge-pop-au',
   'edge-pop-br',
   'edge-pop-ca',
@@ -23,19 +27,44 @@ local edge_regions = [
   'edge-pop-nl',
   'edge-pop-or',
   'edge-pop-qa',
-  'edge-pop-rr',
   'edge-pop-sc',
   'edge-pop-sg',
   'edge-pop-tx',
   'edge-pop-va',
 ];
 
+// All 16 edge clusters. The PoPs are modelled as pseudo-regions (like the uptime
+// clusters) so each one gets its own diff/apply job. Every entry is
+// default-excluded in pipedream.libsonnet, so a service reaches edge only by
+// opting in via include_regions -- the same treatment control and snty-tools
+// get, and for the same reason: most services render no manifests there.
+//
+// Kept as file-level locals rather than fields so that pipeline_groups does not
+// depend on `self` -- pipeline_groups gets copied into other objects, which
+// would rebind `self` and break the reference.
+local edge_all_pop_regions = edge_pop_canary_regions + edge_pop_regions;
+local edge_regions = [edge_region] + edge_all_pop_regions;
+
 {
   edge_regions:: edge_regions,
+  edge_pop_regions:: edge_all_pop_regions,
 
-  // `edge` trails the SaaS regions: these are ingest-path clusters, so they
-  // should only move after the regions they front are known good.
-  group_order: ['s4s2', 'de', 'us', 'us2', 'control', 'prod-control', 'snty-tools', 'edge', 'st'],
+  // The edge groups trail the SaaS regions: these are ingest-path clusters, so
+  // they should only move after the regions they front are known good. Within
+  // edge, the primary cluster goes first, then the canary PoP gates the rest.
+  group_order: [
+    's4s2',
+    'de',
+    'us',
+    'us2',
+    'control',
+    'prod-control',
+    'snty-tools',
+    'edge',
+    'edge-pop-canary',
+    'edge-pop',
+    'st',
+  ],
   // Empty for now — add future test groups here
   test_group_order: [],
   // These groupings consist of user facing deployments
@@ -47,7 +76,9 @@ local edge_regions = [
     control: ['control'],
     'prod-control': ['prod-control'],
     'snty-tools': ['snty-tools'],
-    edge: edge_regions,
+    edge: [edge_region],
+    'edge-pop-canary': edge_pop_canary_regions,
+    'edge-pop': edge_pop_regions,
     st: ['customer-1', 'customer-2', 'customer-7'],
   },
   // Test groups will deploy in parallel to the groups above

--- a/libs/pipedream.libsonnet
+++ b/libs/pipedream.libsonnet
@@ -53,8 +53,11 @@ local wrap_task(task) =
 local is_autodeploy(pipedream_config) =
   !std.objectHas(pipedream_config, 'auto_deploy') || pipedream_config.auto_deploy == true;
 
-// Regions that are excluded by default and must be explicitly included
-local default_excluded_regions = ['control', 'prod-control', 'snty-tools'];
+// Regions that are excluded by default and must be explicitly included.
+// The edge regions are listed here so that adding the `edge` pipeline group
+// does not hand every pipedream service a 16-job edge pipeline for manifests
+// it does not render. Opting in is per-service, via include_regions.
+local default_excluded_regions = ['control', 'prod-control', 'snty-tools'] + getsentry.edge_regions;
 
 local is_excluded_region = function(region, config)
   std.objectHas(config, 'exclude_regions') && std.length(std.find(region, config.exclude_regions)) > 0;
@@ -513,6 +516,11 @@ local pipeline_to_array(pipeline) =
   if pipeline == null then [] else [pipeline];
 
 {
+  // Exported so downstream renderers that reimplement the region filter (e.g.
+  // ops' render_with_pre_diff) can share this list instead of copying it and
+  // drifting out of sync.
+  default_excluded_regions:: default_excluded_regions,
+
   // render generates the trigger pipeline (if manual), group pipelines, and rollback pipeline.
   render(pipedream_config, pipeline_fn, parallel=false)::
     local groups_to_render = std.filter(

--- a/test/testdata/fixtures/pipedream/include-edge.jsonnet
+++ b/test/testdata/fixtures/pipedream/include-edge.jsonnet
@@ -1,13 +1,17 @@
 // The edge regions are default-excluded, so a service reaches them only by
-// naming them in include_regions. This fixture opts into `edge` itself plus two
-// PoP pseudo-regions, and should render a single `deploy-example-edge` pipeline
-// with one job per included region -- and no jobs for the 13 PoPs left out.
+// naming them in include_regions.
+//
+// This fixture opts into all 16 and should render three chained pipelines:
+// `edge` (the primary cluster, an ordinary single-region group), then
+// `edge-pop-canary` holding only pop-rr, then `edge-pop` holding the remaining
+// 14 as parallel jobs. The canary group deploys before the rest and gates them.
+local getsentry = import '../../../../libs/getsentry.libsonnet';
 local pipedream = import '../../../../libs/pipedream.libsonnet';
 
 local pipedream_config = {
   name: 'example',
   auto_deploy: true,
-  include_regions: ['edge', 'edge-pop-au', 'edge-pop-va'],
+  include_regions: getsentry.edge_regions,
 };
 
 local sample = {

--- a/test/testdata/fixtures/pipedream/include-edge.jsonnet
+++ b/test/testdata/fixtures/pipedream/include-edge.jsonnet
@@ -1,0 +1,39 @@
+// The edge regions are default-excluded, so a service reaches them only by
+// naming them in include_regions. This fixture opts into `edge` itself plus two
+// PoP pseudo-regions, and should render a single `deploy-example-edge` pipeline
+// with one job per included region -- and no jobs for the 13 PoPs left out.
+local pipedream = import '../../../../libs/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'example',
+  auto_deploy: true,
+  include_regions: ['edge', 'edge-pop-au', 'edge-pop-va'],
+};
+
+local sample = {
+  pipeline(region):: {
+    materials: {
+      example_repo: {
+        git: 'git@github.com:getsentry/example.git',
+        branch: 'master',
+        destination: 'example',
+      },
+    },
+    stages: [
+      {
+        deploy: {
+          jobs: {
+            ['deploy-' + region]: {
+              elastic_profile_id: 'example',
+              tasks: [
+                { script: './deploy.sh --region=' + region },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
+pipedream.render(pipedream_config, sample.pipeline)

--- a/test/testdata/goldens/getsentry/groups.jsonnet_output-files.golden
+++ b/test/testdata/goldens/getsentry/groups.jsonnet_output-files.golden
@@ -6,6 +6,24 @@
       "de": [
          "de"
       ],
+      "edge": [
+         "edge",
+         "edge-pop-au",
+         "edge-pop-br",
+         "edge-pop-ca",
+         "edge-pop-de",
+         "edge-pop-fi",
+         "edge-pop-in",
+         "edge-pop-jp",
+         "edge-pop-nl",
+         "edge-pop-or",
+         "edge-pop-qa",
+         "edge-pop-rr",
+         "edge-pop-sc",
+         "edge-pop-sg",
+         "edge-pop-tx",
+         "edge-pop-va"
+      ],
       "prod-control": [
          "prod-control"
       ],
@@ -35,6 +53,7 @@
       "control",
       "prod-control",
       "snty-tools",
+      "edge",
       "st"
    ]
 }

--- a/test/testdata/goldens/getsentry/groups.jsonnet_output-files.golden
+++ b/test/testdata/goldens/getsentry/groups.jsonnet_output-files.golden
@@ -7,7 +7,9 @@
          "de"
       ],
       "edge": [
-         "edge",
+         "edge"
+      ],
+      "edge-pop": [
          "edge-pop-au",
          "edge-pop-br",
          "edge-pop-ca",
@@ -18,11 +20,13 @@
          "edge-pop-nl",
          "edge-pop-or",
          "edge-pop-qa",
-         "edge-pop-rr",
          "edge-pop-sc",
          "edge-pop-sg",
          "edge-pop-tx",
          "edge-pop-va"
+      ],
+      "edge-pop-canary": [
+         "edge-pop-rr"
       ],
       "prod-control": [
          "prod-control"
@@ -54,6 +58,8 @@
       "prod-control",
       "snty-tools",
       "edge",
+      "edge-pop-canary",
+      "edge-pop",
       "st"
    ]
 }

--- a/test/testdata/goldens/pipedream/include-edge.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/include-edge.jsonnet_output-files.golden
@@ -54,13 +54,227 @@
          }
       }
    },
+   "deploy-example-edge-pop-canary.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-edge-pop-canary": {
+            "display_order": 7,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "edge-pop-rr"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-edge-pipeline-complete": {
+                  "pipeline": "deploy-example-edge",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-edge-pop-rr": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "./deploy.sh --region=edge-pop-rr"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-edge-pop.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-edge-pop": {
+            "display_order": 8,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "edge-pop-au,edge-pop-br,edge-pop-ca,edge-pop-de,edge-pop-fi,edge-pop-in,edge-pop-jp,edge-pop-nl,edge-pop-or,edge-pop-qa,edge-pop-sc,edge-pop-sg,edge-pop-tx,edge-pop-va"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-edge-pop-canary-pipeline-complete": {
+                  "pipeline": "deploy-example-edge-pop-canary",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-edge-pop-au": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-au"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-br": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-br"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-ca": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-ca"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-de": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-de"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-fi": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-fi"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-in": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-in"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-jp": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-jp"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-nl": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-nl"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-or": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-or"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-qa": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-qa"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-sc": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-sc"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-sg": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-sg"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-tx": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-tx"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-va": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-va"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
    "deploy-example-edge.yaml": {
       "format_version": 10,
       "pipelines": {
          "deploy-example-edge": {
             "display_order": 6,
             "environment_variables": {
-               "PIPEDREAM_GROUP_REGIONS": "edge,edge-pop-au,edge-pop-va"
+               "PIPEDREAM_GROUP_REGIONS": "edge"
             },
             "group": "example",
             "materials": {
@@ -82,23 +296,7 @@
                            "elastic_profile_id": "example",
                            "tasks": [
                               {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge"
-                              }
-                           ]
-                        },
-                        "deploy-edge-pop-au": {
-                           "elastic_profile_id": "example",
-                           "tasks": [
-                              {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-au"
-                              }
-                           ]
-                        },
-                        "deploy-edge-pop-va": {
-                           "elastic_profile_id": "example",
-                           "tasks": [
-                              {
-                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-va"
+                                 "script": "./deploy.sh --region=edge"
                               }
                            ]
                         }
@@ -180,14 +378,14 @@
       "format_version": 10,
       "pipelines": {
          "deploy-example-st": {
-            "display_order": 7,
+            "display_order": 9,
             "environment_variables": {
                "PIPEDREAM_GROUP_REGIONS": "customer-1,customer-2,customer-7"
             },
             "group": "example",
             "materials": {
-               "deploy-example-edge-pipeline-complete": {
-                  "pipeline": "deploy-example-edge",
+               "deploy-example-edge-pop-pipeline-complete": {
+                  "pipeline": "deploy-example-edge-pop",
                   "stage": "pipeline-complete"
                },
                "example_repo": {

--- a/test/testdata/goldens/pipedream/include-edge.jsonnet_output-files.golden
+++ b/test/testdata/goldens/pipedream/include-edge.jsonnet_output-files.golden
@@ -1,0 +1,360 @@
+{
+   "deploy-example-de.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-de": {
+            "display_order": 3,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "de"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-s4s2-pipeline-complete": {
+                  "pipeline": "deploy-example-s4s2",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-de": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "./deploy.sh --region=de"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-edge.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-edge": {
+            "display_order": 6,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "edge,edge-pop-au,edge-pop-va"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-us2-pipeline-complete": {
+                  "pipeline": "deploy-example-us2",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-edge": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-au": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-au"
+                              }
+                           ]
+                        },
+                        "deploy-edge-pop-va": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-va"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-s4s2.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-s4s2": {
+            "display_order": 2,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "s4s2"
+            },
+            "group": "example",
+            "materials": {
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-s4s2": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "./deploy.sh --region=s4s2"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-st.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-st": {
+            "display_order": 7,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "customer-1,customer-2,customer-7"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-edge-pipeline-complete": {
+                  "pipeline": "deploy-example-edge",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-customer-1": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=customer-1"
+                              }
+                           ]
+                        },
+                        "deploy-customer-2": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=customer-2"
+                              }
+                           ]
+                        },
+                        "deploy-customer-7": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=customer-7"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-us.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-us": {
+            "display_order": 4,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "us"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-de-pipeline-complete": {
+                  "pipeline": "deploy-example-de",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-us": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "./deploy.sh --region=us"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "deploy-example-us2.yaml": {
+      "format_version": 10,
+      "pipelines": {
+         "deploy-example-us2": {
+            "display_order": 5,
+            "environment_variables": {
+               "PIPEDREAM_GROUP_REGIONS": "us2"
+            },
+            "group": "example",
+            "materials": {
+               "deploy-example-us-pipeline-complete": {
+                  "pipeline": "deploy-example-us",
+                  "stage": "pipeline-complete"
+               },
+               "example_repo": {
+                  "branch": "master",
+                  "destination": "example",
+                  "git": "git@github.com:getsentry/example.git"
+               }
+            },
+            "stages": [
+               {
+                  "deploy": {
+                     "jobs": {
+                        "deploy-us2": {
+                           "elastic_profile_id": "example",
+                           "tasks": [
+                              {
+                                 "script": "./deploy.sh --region=us2"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               },
+               {
+                  "pipeline-complete": {
+                     "fetch_materials": false,
+                     "jobs": {
+                        "pipeline-complete": {
+                           "tasks": [
+                              {
+                                 "exec": {
+                                    "command": true
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/include-edge.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/include-edge.jsonnet_single-file.golden
@@ -1,0 +1,333 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "deploy-example-de": {
+         "display_order": 3,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "de"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-s4s2-pipeline-complete": {
+               "pipeline": "deploy-example-s4s2",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
+                     "deploy-de": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "./deploy.sh --region=de"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-edge": {
+         "display_order": 6,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "edge,edge-pop-au,edge-pop-va"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-us2-pipeline-complete": {
+               "pipeline": "deploy-example-us2",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
+                     "deploy-edge": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-au": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-au"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-va": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-va"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-s4s2": {
+         "display_order": 2,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "s4s2"
+         },
+         "group": "example",
+         "materials": {
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
+                     "deploy-s4s2": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "./deploy.sh --region=s4s2"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-st": {
+         "display_order": 7,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "customer-1,customer-2,customer-7"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-edge-pipeline-complete": {
+               "pipeline": "deploy-example-edge",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
+                     "deploy-customer-1": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=customer-1"
+                           }
+                        ]
+                     },
+                     "deploy-customer-2": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=customer-2"
+                           }
+                        ]
+                     },
+                     "deploy-customer-7": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=customer-7"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-us": {
+         "display_order": 4,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "us"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-de-pipeline-complete": {
+               "pipeline": "deploy-example-de",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
+                     "deploy-us": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "./deploy.sh --region=us"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-us2": {
+         "display_order": 5,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "us2"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-us-pipeline-complete": {
+               "pipeline": "deploy-example-us",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
+                     "deploy-us2": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "./deploy.sh --region=us2"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/test/testdata/goldens/pipedream/include-edge.jsonnet_single-file.golden
+++ b/test/testdata/goldens/pipedream/include-edge.jsonnet_single-file.golden
@@ -54,7 +54,7 @@
       "deploy-example-edge": {
          "display_order": 6,
          "environment_variables": {
-            "PIPEDREAM_GROUP_REGIONS": "edge,edge-pop-au,edge-pop-va"
+            "PIPEDREAM_GROUP_REGIONS": "edge"
          },
          "group": "example",
          "materials": {
@@ -76,10 +76,52 @@
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
-                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge"
+                              "script": "./deploy.sh --region=edge"
                            }
                         ]
-                     },
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-edge-pop": {
+         "display_order": 8,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "edge-pop-au,edge-pop-br,edge-pop-ca,edge-pop-de,edge-pop-fi,edge-pop-in,edge-pop-jp,edge-pop-nl,edge-pop-or,edge-pop-qa,edge-pop-sc,edge-pop-sg,edge-pop-tx,edge-pop-va"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-edge-pop-canary-pipeline-complete": {
+               "pipeline": "deploy-example-edge-pop-canary",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
                      "deploy-edge-pop-au": {
                         "elastic_profile_id": "example",
                         "tasks": [
@@ -88,11 +130,157 @@
                            }
                         ]
                      },
+                     "deploy-edge-pop-br": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-br"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-ca": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-ca"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-de": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-de"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-fi": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-fi"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-in": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-in"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-jp": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-jp"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-nl": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-nl"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-or": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-or"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-qa": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-qa"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-sc": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-sc"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-sg": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-sg"
+                           }
+                        ]
+                     },
+                     "deploy-edge-pop-tx": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-tx"
+                           }
+                        ]
+                     },
                      "deploy-edge-pop-va": {
                         "elastic_profile_id": "example",
                         "tasks": [
                            {
                               "script": "if [ -n \"${PIPEDREAM_GROUP_REGIONS:-}\" ] && [ -n \"${SENTRY_REGION:-}\" ]; then\n  case \",${PIPEDREAM_GROUP_REGIONS},\" in\n    *\",${SENTRY_REGION},\"*) ;;\n    *)\n      echo \"Skipping $SENTRY_REGION (not in PIPEDREAM_GROUP_REGIONS=$PIPEDREAM_GROUP_REGIONS)\"\n      exit 0\n      ;;\n  esac\nfi\n./deploy.sh --region=edge-pop-va"
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "fetch_materials": false,
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      },
+      "deploy-example-edge-pop-canary": {
+         "display_order": 7,
+         "environment_variables": {
+            "PIPEDREAM_GROUP_REGIONS": "edge-pop-rr"
+         },
+         "group": "example",
+         "materials": {
+            "deploy-example-edge-pipeline-complete": {
+               "pipeline": "deploy-example-edge",
+               "stage": "pipeline-complete"
+            },
+            "example_repo": {
+               "branch": "master",
+               "destination": "example",
+               "git": "git@github.com:getsentry/example.git"
+            }
+         },
+         "stages": [
+            {
+               "deploy": {
+                  "jobs": {
+                     "deploy-edge-pop-rr": {
+                        "elastic_profile_id": "example",
+                        "tasks": [
+                           {
+                              "script": "./deploy.sh --region=edge-pop-rr"
                            }
                         ]
                      }
@@ -164,14 +352,14 @@
          ]
       },
       "deploy-example-st": {
-         "display_order": 7,
+         "display_order": 9,
          "environment_variables": {
             "PIPEDREAM_GROUP_REGIONS": "customer-1,customer-2,customer-7"
          },
          "group": "example",
          "materials": {
-            "deploy-example-edge-pipeline-complete": {
-               "pipeline": "deploy-example-edge",
+            "deploy-example-edge-pop-pipeline-complete": {
+               "pipeline": "deploy-example-edge-pop",
                "stage": "pipeline-complete"
             },
             "example_repo": {


### PR DESCRIPTION
**This is step 1 of 3.** It must merge **and be tagged `v3.1.0`** before the `getsentry/ops` PR can build. See "Rollout order" below.

## Why

The `edge` region — `edge/default` plus the 15 `edge/pop-*` clusters — has no generated GoCD pipeline applying any of its materialized manifests today. Everything there is applied by hand.

This isn't a missing config value, it's structural. `pipedream.render` iterates `getsentry.group_order` → `get_targets(group)` → `pipeline_groups`, and that set has no `edge` and no PoP entry. `include_regions` can't help either: per `should_include_region` it only re-admits regions already in `default_excluded_regions`, so there is no string you can put in a service's `include_regions` today that produces an edge pipeline.

## Grouping

Three groups, chained in this order:

| Group | Regions | Why |
|---|---|---|
| `edge` | `edge` | The sentry-edge `primary` cluster. An ordinary region cluster, so it gets an ordinary single-region group — exactly like `us`, `de`, `s4s2`, `control`. |
| `edge-pop-canary` | `edge-pop-rr` | pop-rr is the canary cluster for the PoP fleet. The PoPs have no in-cluster canary deployments the way the SaaS regions do; one whole cluster plays that role. Alone in its group, so sequential group chaining makes it a real gate for the rest. |
| `edge-pop` | the other 14 | One group means parallel jobs in one pipeline. There is no meaningful order between PoPs, and alphabetical order in particular implies a sequencing that doesn't exist. Adding a PoP needs no ordering decision. |

Resulting chain: `… → snty-tools → edge → edge-pop-canary → edge-pop → st`.

A side benefit of the 14 sharing a group: `PIPEDREAM_GROUP_REGIONS` lets an operator deploy a subset from "Trigger with options". Single-region groups skip that gate, so it wouldn't have been available if each PoP were its own group.

The edge groups trail the SaaS regions because these are ingest-path clusters — they should only move after the regions they front are known good.

## The PoPs as pseudo-regions

The 15 PoPs are modelled as pseudo-regions (`edge-pop-au`, …) the way the uptime clusters already are, so each cluster gets its own diff/apply job rather than one job fanning out internally.

## Default-exclusion

All 16 edge regions go into `default_excluded_regions`.

This part is not optional. Without it, adding the groups hands **every** pipedream service — getsentry, snuba, taskbroker, ~50 of them — an edge pipeline for manifests they don't render. Only 7 services render anything into edge at all.

To be clear about what this is and isn't: it's the same treatment `control`, `prod-control` and `snty-tools` already get, and for the same reason. Those are ordinary region clusters too. Default-exclusion is about "most services don't deploy here", not about edge being structurally special — `edge` is a plain single-region group like any other.

## Implementation note

The region lists are file-level `local`s, not fields. `pipeline_groups` gets copied into other objects (`test/testdata/fixtures/getsentry/groups.jsonnet` does exactly this), which rebinds `self` — a `self.edge_regions` reference fails to resolve there.

Also exports `default_excluded_regions`, plus `edge_regions` (all 16) and `edge_pop_regions` (the 15 PoPs) so consumers don't filter by hand. `ops`' `render_with_pre_diff` kept its own copy of the excluded-regions list, which was already a latent drift hazard and this change would have triggered it (details in the ops PR).

## Testing

`npm run test` — 59 pass (was 57).

The evidence that the default-exclusion landed correctly is what *didn't* change: **all 48 pipedream goldens are byte-identical**. The only golden that moved is `getsentry/groups`, the group registry itself. No service gained a pipeline.

New fixture `pipedream/include-edge.jsonnet` opts into all 16 and pins the structure:

```
deploy-example-edge              1 job  (deploy-edge)          upstream: us2
deploy-example-edge-pop-canary   1 job  (deploy-edge-pop-rr)   upstream: edge
deploy-example-edge-pop         14 jobs (parallel)             upstream: edge-pop-canary
```

## Rollout order

1. **This PR** → merge, then tag `v3.1.0`.
2. `getsentry/devinfra-deployment-service#899` — region configs. Independent of this; can merge any time.
3. `getsentry/ops#22360` — pin bump, region mapping, per-service opt-in, cluster access. Needs the tag from step 1.